### PR TITLE
Add monthly income and transfer pages

### DIFF
--- a/budget-tracker-backend/Controllers/PagesController.cs
+++ b/budget-tracker-backend/Controllers/PagesController.cs
@@ -28,7 +28,7 @@ public class PagesController : BaseApiController
     /// </summary>
     /// <param name="month">1–12</param>
     /// <param name="year">необов’язково, за замовчанням – поточний</param>
-    [HttpGet("incomeByMonth/{month:int}")]
+    [HttpGet("incomesByMonth/{month:int}")]
     public async Task<IActionResult> IncomeByMonth(int month, [FromQuery] int? year)
     {
         var query = new GetIncomesByMonthQuery(month, year);

--- a/budget-tracker-backend/Controllers/PagesController.cs
+++ b/budget-tracker-backend/Controllers/PagesController.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using budget_tracker_backend.MediatR.Pages.ExpensesByMonth;
+using budget_tracker_backend.MediatR.Pages.IncomesByMonth;
+using budget_tracker_backend.MediatR.Pages.TransfersByMonth;
 using budget_tracker_backend.Controllers.Interfaces;
 
 namespace budget_tracker_backend.Controllers;
@@ -17,6 +19,32 @@ public class PagesController : BaseApiController
     public async Task<IActionResult> ExpensesByMonth(int month, [FromQuery] int? year)
     {
         var query = new GetExpensesByMonthQuery(month, year);
+        var result = await Mediator.Send(query);
+        return HandleResult(result);
+    }
+
+    /// <summary>
+    /// Надходження за місяць.
+    /// </summary>
+    /// <param name="month">1–12</param>
+    /// <param name="year">необов’язково, за замовчанням – поточний</param>
+    [HttpGet("incomeByMonth/{month:int}")]
+    public async Task<IActionResult> IncomeByMonth(int month, [FromQuery] int? year)
+    {
+        var query = new GetIncomesByMonthQuery(month, year);
+        var result = await Mediator.Send(query);
+        return HandleResult(result);
+    }
+
+    /// <summary>
+    /// Перекази за місяць.
+    /// </summary>
+    /// <param name="month">1–12</param>
+    /// <param name="year">необов’язково, за замовчанням – поточний</param>
+    [HttpGet("transfersByMonth/{month:int}")]
+    public async Task<IActionResult> TransfersByMonth(int month, [FromQuery] int? year)
+    {
+        var query = new GetTransfersByMonthQuery(month, year);
         var result = await Mediator.Send(query);
         return HandleResult(result);
     }

--- a/budget-tracker-backend/Dto/Pages/IncomesByMonthDto.cs
+++ b/budget-tracker-backend/Dto/Pages/IncomesByMonthDto.cs
@@ -1,0 +1,26 @@
+namespace budget_tracker_backend.Dto.Pages;
+
+/// <summary>
+/// Модель сторінки «Надходження за місяць». —Для віддачі у фронт.
+/// </summary>
+public class IncomesByMonthDto
+{
+    public DateTime Start { get; set; }
+    public DateTime End { get; set; }
+    public List<IncomeTxDto> Transactions { get; set; } = new();
+}
+
+/// <summary>
+/// Коротка проекція транзакцій-надходжень.
+/// </summary>
+public class IncomeTxDto
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = null!;
+    public decimal Amount { get; set; }
+    public string CurrencySymbol { get; set; } = null!;
+    public string CategoryTitle { get; set; } = null!;
+    public string AccountTitle { get; set; } = null!;
+    public DateTime Date { get; set; }
+    public string? Description { get; set; }
+}

--- a/budget-tracker-backend/Dto/Pages/TransfersByMonthDto.cs
+++ b/budget-tracker-backend/Dto/Pages/TransfersByMonthDto.cs
@@ -1,0 +1,27 @@
+namespace budget_tracker_backend.Dto.Pages;
+
+/// <summary>
+/// Модель сторінки «Перекази за місяць». —Для віддачі у фронт.
+/// </summary>
+public class TransfersByMonthDto
+{
+    public DateTime Start { get; set; }
+    public DateTime End { get; set; }
+    public List<TransferTxDto> Transactions { get; set; } = new();
+}
+
+/// <summary>
+/// Коротка проекція транзакцій-переказів.
+/// </summary>
+public class TransferTxDto
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = null!;
+    public decimal Amount { get; set; }
+    public string CurrencySymbol { get; set; } = null!;
+    public string CategoryTitle { get; set; } = null!;
+    public string AccountFromTitle { get; set; } = null!;
+    public string AccountToTitle { get; set; } = null!;
+    public DateTime Date { get; set; }
+    public string? Description { get; set; }
+}

--- a/budget-tracker-backend/Mapping/Pages/IncomesByMonthProfile.cs
+++ b/budget-tracker-backend/Mapping/Pages/IncomesByMonthProfile.cs
@@ -1,0 +1,19 @@
+using AutoMapper;
+using budget_tracker_backend.Dto.Pages;
+using budget_tracker_backend.Models;
+
+namespace budget_tracker_backend.Mapping.Pages;
+
+public class IncomesByMonthProfile : Profile
+{
+    public IncomesByMonthProfile()
+    {
+        CreateMap<Transaction, IncomeTxDto>()
+            .ForMember(d => d.CurrencySymbol,
+                m => m.MapFrom(s => s.Currency.Symbol))
+            .ForMember(d => d.CategoryTitle,
+                m => m.MapFrom(s => s.Category.Title))
+            .ForMember(d => d.AccountTitle,
+                m => m.MapFrom(s => s.ToAccount.Title));
+    }
+}

--- a/budget-tracker-backend/Mapping/Pages/TransfersByMonthProfile.cs
+++ b/budget-tracker-backend/Mapping/Pages/TransfersByMonthProfile.cs
@@ -1,0 +1,21 @@
+using AutoMapper;
+using budget_tracker_backend.Dto.Pages;
+using budget_tracker_backend.Models;
+
+namespace budget_tracker_backend.Mapping.Pages;
+
+public class TransfersByMonthProfile : Profile
+{
+    public TransfersByMonthProfile()
+    {
+        CreateMap<Transaction, TransferTxDto>()
+            .ForMember(d => d.CurrencySymbol,
+                m => m.MapFrom(s => s.Currency.Symbol))
+            .ForMember(d => d.CategoryTitle,
+                m => m.MapFrom(s => s.Category.Title))
+            .ForMember(d => d.AccountFromTitle,
+                m => m.MapFrom(s => s.FromAccount.Title))
+            .ForMember(d => d.AccountToTitle,
+                m => m.MapFrom(s => s.ToAccount.Title));
+    }
+}

--- a/budget-tracker-backend/MediatR/Pages/IncomesByMonth/GetIncomesByMonthHandler.cs
+++ b/budget-tracker-backend/MediatR/Pages/IncomesByMonth/GetIncomesByMonthHandler.cs
@@ -1,0 +1,51 @@
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using budget_tracker_backend.Data;
+using budget_tracker_backend.Dto.Pages;
+using budget_tracker_backend.Models.Enums;
+
+namespace budget_tracker_backend.MediatR.Pages.IncomesByMonth;
+
+public class GetIncomesByMonthHandler
+    : IRequestHandler<GetIncomesByMonthQuery, Result<IncomesByMonthDto>>
+{
+    private readonly ApplicationDbContext _ctx;
+    private readonly IMapper _mapper;
+
+    public GetIncomesByMonthHandler(ApplicationDbContext ctx, IMapper mapper)
+    {
+        _ctx = ctx; _mapper = mapper;
+    }
+
+    public async Task<Result<IncomesByMonthDto>> Handle(
+        GetIncomesByMonthQuery rq, CancellationToken ct)
+    {
+        if (rq.Month is < 1 or > 12)
+            return Result.Fail("Month must be 1-12");
+
+        var year = rq.Year ?? DateTime.Today.Year;
+        var start = new DateTime(year, rq.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = start.AddMonths(1);
+
+        var tx = await _ctx.Transactions
+            .Include(t => t.Currency)
+            .Include(t => t.Category)
+            .Include(t => t.ToAccount)
+            .Where(t =>
+                   t.Type == TransactionCategoryType.Income &&
+                   t.Date >= start && t.Date < end)
+            .AsNoTracking()
+            .ToListAsync(ct);
+
+        var dto = new IncomesByMonthDto
+        {
+            Start = start,
+            End = end,
+            Transactions = _mapper.Map<List<IncomeTxDto>>(tx)
+        };
+
+        return Result.Ok(dto);
+    }
+}

--- a/budget-tracker-backend/MediatR/Pages/IncomesByMonth/GetIncomesByMonthQuery.cs
+++ b/budget-tracker-backend/MediatR/Pages/IncomesByMonth/GetIncomesByMonthQuery.cs
@@ -1,0 +1,9 @@
+using FluentResults;
+using MediatR;
+using budget_tracker_backend.Dto.Pages;
+
+namespace budget_tracker_backend.MediatR.Pages.IncomesByMonth;
+
+/// <param name="Month">1–12</param>
+/// <param name="Year">Опціонально. Якщо null — береться поточний рік</param>
+public record GetIncomesByMonthQuery(int Month, int? Year = null) : IRequest<Result<IncomesByMonthDto>>;

--- a/budget-tracker-backend/MediatR/Pages/TransfersByMonth/GetTransfersByMonthHandler.cs
+++ b/budget-tracker-backend/MediatR/Pages/TransfersByMonth/GetTransfersByMonthHandler.cs
@@ -1,0 +1,52 @@
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using budget_tracker_backend.Data;
+using budget_tracker_backend.Dto.Pages;
+using budget_tracker_backend.Models.Enums;
+
+namespace budget_tracker_backend.MediatR.Pages.TransfersByMonth;
+
+public class GetTransfersByMonthHandler
+    : IRequestHandler<GetTransfersByMonthQuery, Result<TransfersByMonthDto>>
+{
+    private readonly ApplicationDbContext _ctx;
+    private readonly IMapper _mapper;
+
+    public GetTransfersByMonthHandler(ApplicationDbContext ctx, IMapper mapper)
+    {
+        _ctx = ctx; _mapper = mapper;
+    }
+
+    public async Task<Result<TransfersByMonthDto>> Handle(
+        GetTransfersByMonthQuery rq, CancellationToken ct)
+    {
+        if (rq.Month is < 1 or > 12)
+            return Result.Fail("Month must be 1-12");
+
+        var year = rq.Year ?? DateTime.Today.Year;
+        var start = new DateTime(year, rq.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = start.AddMonths(1);
+
+        var tx = await _ctx.Transactions
+            .Include(t => t.Currency)
+            .Include(t => t.Category)
+            .Include(t => t.FromAccount)
+            .Include(t => t.ToAccount)
+            .Where(t =>
+                   t.Type == TransactionCategoryType.Transaction &&
+                   t.Date >= start && t.Date < end)
+            .AsNoTracking()
+            .ToListAsync(ct);
+
+        var dto = new TransfersByMonthDto
+        {
+            Start = start,
+            End = end,
+            Transactions = _mapper.Map<List<TransferTxDto>>(tx)
+        };
+
+        return Result.Ok(dto);
+    }
+}

--- a/budget-tracker-backend/MediatR/Pages/TransfersByMonth/GetTransfersByMonthQuery.cs
+++ b/budget-tracker-backend/MediatR/Pages/TransfersByMonth/GetTransfersByMonthQuery.cs
@@ -1,0 +1,9 @@
+using FluentResults;
+using MediatR;
+using budget_tracker_backend.Dto.Pages;
+
+namespace budget_tracker_backend.MediatR.Pages.TransfersByMonth;
+
+/// <param name="Month">1–12</param>
+/// <param name="Year">Опціонально. Якщо null — береться поточний рік</param>
+public record GetTransfersByMonthQuery(int Month, int? Year = null) : IRequest<Result<TransfersByMonthDto>>;


### PR DESCRIPTION
## Summary
- add DTOs for the income and transfer pages
- implement MediatR queries and handlers for monthly incomes and transfers
- map transaction entities to new DTOs
- expose new endpoints in `PagesController`

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604d41510c8330bc3470e461fe79a6