### PR TITLE
Introduce AccountManager service

### DIFF
--- a/budget-tracker-backend/MediatR/Accounts/Commands/Create/CreateAccountHandler.cs
+++ b/budget-tracker-backend/MediatR/Accounts/Commands/Create/CreateAccountHandler.cs
@@ -1,8 +1,6 @@
 ﻿using AutoMapper;
-using budget_tracker_backend.Data;
 using budget_tracker_backend.Dto.Accounts;
-using budget_tracker_backend.Exceptions;
-using budget_tracker_backend.Models;
+using budget_tracker_backend.Services.Accounts;
 using FluentResults;
 using MediatR;
 
@@ -10,37 +8,19 @@ namespace budget_tracker_backend.MediatR.Accounts.Commands.Create;
 
 public class CreateAccountHandler : IRequestHandler<CreateAccountCommand, Result<AccountDto>>
 {
-    private readonly ApplicationDbContext _dbContext;
+    private readonly IAccountManager _manager;
     private readonly IMapper _mapper;
 
-    public CreateAccountHandler(ApplicationDbContext dbContext, IMapper mapper)
+    public CreateAccountHandler(IAccountManager manager, IMapper mapper)
     {
-        _dbContext = dbContext;
+        _manager = manager;
         _mapper = mapper;
     }
 
     public async Task<Result<AccountDto>> Handle(CreateAccountCommand request, CancellationToken cancellationToken)
     {
-        // Mapping DTO → model
-        var entity = _mapper.Map<Account>(request.NewAccount);
-        if (entity == null)
-        {
-            const string errorMsg = "Cannot map CreateAccountDto to Account entity";
-            throw new CustomException(errorMsg, StatusCodes.Status400BadRequest);
-        }
-
-        // Add record to DbContext
-        await _dbContext.Accounts.AddAsync(entity, cancellationToken);
-        var saveResult = await _dbContext.SaveChangesAsync(cancellationToken) > 0;
-
-        if (!saveResult)
-        {
-            const string errorMsg = "Failed to create an account";
-            throw new CustomException(errorMsg, StatusCodes.Status500InternalServerError);
-        }
-
-        // Returning a successful result
-        var resultDto = _mapper.Map<AccountDto>(entity);
-        return Result.Ok(resultDto);
+        var account = await _manager.CreateAsync(request.NewAccount, cancellationToken);
+        var dto = _mapper.Map<AccountDto>(account);
+        return Result.Ok(dto);
     }
 }

--- a/budget-tracker-backend/MediatR/Accounts/Commands/Delete/DeleteAccountHandler.cs
+++ b/budget-tracker-backend/MediatR/Accounts/Commands/Delete/DeleteAccountHandler.cs
@@ -1,5 +1,4 @@
-﻿using budget_tracker_backend.Data;
-using budget_tracker_backend.Exceptions;
+﻿using budget_tracker_backend.Services.Accounts;
 using FluentResults;
 using MediatR;
 
@@ -7,30 +6,16 @@ namespace budget_tracker_backend.MediatR.Accounts.Commands.Delete;
 
 public class DeleteAccountHandler : IRequestHandler<DeleteAccountCommand, Result<bool>>
 {
-    private readonly ApplicationDbContext _dbContext;
+    private readonly IAccountManager _manager;
 
-    public DeleteAccountHandler(ApplicationDbContext dbContext)
+    public DeleteAccountHandler(IAccountManager manager)
     {
-        _dbContext = dbContext;
+        _manager = manager;
     }
 
     public async Task<Result<bool>> Handle(DeleteAccountCommand request, CancellationToken cancellationToken)
     {
-        var account = await _dbContext.Accounts.FindAsync(new object[] { request.Id }, cancellationToken);
-        if (account == null)
-        {
-            const string errorMsg = "Account not found";
-            throw new CustomException(errorMsg, StatusCodes.Status404NotFound);
-        }
-
-        _dbContext.Accounts.Remove(account);
-        var saveResult = await _dbContext.SaveChangesAsync(cancellationToken) > 0;
-        if (!saveResult)
-        {
-            const string errorMsg = "Failed to delete account";
-            throw new CustomException(errorMsg, StatusCodes.Status500InternalServerError);
-        }
-
-        return Result.Ok(true);
+        var result = await _manager.DeleteAsync(request.Id, cancellationToken);
+        return Result.Ok(result);
     }
 }

--- a/budget-tracker-backend/MediatR/Accounts/Commands/Update/UpdateAccountHandler.cs
+++ b/budget-tracker-backend/MediatR/Accounts/Commands/Update/UpdateAccountHandler.cs
@@ -1,7 +1,6 @@
 ﻿using AutoMapper;
-using budget_tracker_backend.Data;
 using budget_tracker_backend.Dto.Accounts;
-using budget_tracker_backend.Exceptions;
+using budget_tracker_backend.Services.Accounts;
 using FluentResults;
 using MediatR;
 
@@ -9,40 +8,19 @@ namespace budget_tracker_backend.MediatR.Accounts.Commands.Update;
 
 public class UpdateAccountHandler : IRequestHandler<UpdateAccountCommand, Result<AccountDto>>
 {
-    private readonly ApplicationDbContext _dbContext;
+    private readonly IAccountManager _manager;
     private readonly IMapper _mapper;
 
-    public UpdateAccountHandler(ApplicationDbContext dbContext, IMapper mapper)
+    public UpdateAccountHandler(IAccountManager manager, IMapper mapper)
     {
-        _dbContext = dbContext;
+        _manager = manager;
         _mapper = mapper;
     }
 
     public async Task<Result<AccountDto>> Handle(UpdateAccountCommand request, CancellationToken cancellationToken)
     {
-        // Pull from the database
-        var existing = await _dbContext.Accounts.FindAsync(new object[] { request.UpdatedAccount.Id }, cancellationToken);
-        if (existing == null)
-        {
-            const string errorMsg = "Account not found";
-            throw new CustomException(errorMsg, StatusCodes.Status404NotFound);
-        }
-
-        // Transfer data from DTO to entity
-        existing.Title = request.UpdatedAccount.Title;
-        existing.Amount = request.UpdatedAccount.Amount;
-        existing.CurrencyId = request.UpdatedAccount.CurrencyId;
-        existing.Description = request.UpdatedAccount.Description;
-
-        _dbContext.Accounts.Update(existing);
-        var saveResult = await _dbContext.SaveChangesAsync(cancellationToken) > 0;
-        if (!saveResult)
-        {
-            const string errorMsg = "Failed to update account";
-            throw new CustomException(errorMsg, StatusCodes.Status500InternalServerError);
-        }
-
-        var resultDto = _mapper.Map<AccountDto>(existing);
-        return Result.Ok(resultDto);
+        var account = await _manager.UpdateAsync(request.UpdatedAccount, cancellationToken);
+        var dto = _mapper.Map<AccountDto>(account);
+        return Result.Ok(dto);
     }
 }

--- a/budget-tracker-backend/MediatR/Accounts/Queries/GetAll/GetAllAccountsHandler.cs
+++ b/budget-tracker-backend/MediatR/Accounts/Queries/GetAll/GetAllAccountsHandler.cs
@@ -1,30 +1,25 @@
 ﻿using AutoMapper;
-using budget_tracker_backend.Data;
 using budget_tracker_backend.Dto.Accounts;
+using budget_tracker_backend.Services.Accounts;
 using FluentResults;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
 
 namespace budget_tracker_backend.MediatR.Accounts.Queries.GetAll;
 
 public class GetAllAccountsHandler : IRequestHandler<GetAllAccountsQuery, Result<IEnumerable<AccountDto>>>
 {
-    private readonly ApplicationDbContext _dbContext;
+    private readonly IAccountManager _manager;
     private readonly IMapper _mapper;
 
-    public GetAllAccountsHandler(ApplicationDbContext dbContext, IMapper mapper)
+    public GetAllAccountsHandler(IAccountManager manager, IMapper mapper)
     {
-        _dbContext = dbContext;
+        _manager = manager;
         _mapper = mapper;
     }
 
     public async Task<Result<IEnumerable<AccountDto>>> Handle(GetAllAccountsQuery request, CancellationToken cancellationToken)
     {
-        var accounts = await _dbContext.Accounts
-            .AsNoTracking()
-            .ToListAsync(cancellationToken);
-
-        // Map Account list → AccountDto list
+        var accounts = await _manager.GetAllAsync(cancellationToken);
         var dtos = _mapper.Map<IEnumerable<AccountDto>>(accounts);
         return Result.Ok(dtos);
     }

--- a/budget-tracker-backend/MediatR/Accounts/Queries/GetById/GetAccountByIdHandler.cs
+++ b/budget-tracker-backend/MediatR/Accounts/Queries/GetById/GetAccountByIdHandler.cs
@@ -1,6 +1,6 @@
 ﻿using AutoMapper;
-using budget_tracker_backend.Data;
 using budget_tracker_backend.Dto.Accounts;
+using budget_tracker_backend.Services.Accounts;
 using budget_tracker_backend.Exceptions;
 using FluentResults;
 using MediatR;
@@ -9,18 +9,18 @@ namespace budget_tracker_backend.MediatR.Accounts.Queries.GetById;
 
 public class GetAccountByIdHandler : IRequestHandler<GetAccountByIdQuery, Result<AccountDto>>
 {
-    private readonly ApplicationDbContext _dbContext;
+    private readonly IAccountManager _manager;
     private readonly IMapper _mapper;
 
-    public GetAccountByIdHandler(ApplicationDbContext dbContext, IMapper mapper)
+    public GetAccountByIdHandler(IAccountManager manager, IMapper mapper)
     {
-        _dbContext = dbContext;
+        _manager = manager;
         _mapper = mapper;
     }
 
     public async Task<Result<AccountDto>> Handle(GetAccountByIdQuery request, CancellationToken cancellationToken)
     {
-        var account = await _dbContext.Accounts.FindAsync(new object[] { request.Id }, cancellationToken);
+        var account = await _manager.GetByIdAsync(request.Id, cancellationToken);
         if (account == null)
         {
             const string errorMsg = "Account not found";

--- a/budget-tracker-backend/Program.cs
+++ b/budget-tracker-backend/Program.cs
@@ -1,4 +1,5 @@
 using budget_tracker_backend.Data;
+using budget_tracker_backend.Services.Accounts;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.EntityFrameworkCore;
 using MediatR;
@@ -7,7 +8,8 @@ var builder = WebApplication.CreateBuilder(args);
 var currentAssemblies = AppDomain.CurrentDomain.GetAssemblies();
 
 
-// Подключаем EF Core и MS SQL
+builder.Services.AddScoped<IAccountManager, AccountManager>();
+// ГЏГ®Г¤ГЄГ«ГѕГ·Г ГҐГ¬ EF Core ГЁ MS SQL
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
@@ -39,7 +41,7 @@ app.UseHttpsRedirection();
 app.UseAuthorization();
 app.MapControllers();
 
-app.UseCors("AllowReact"); // Включаем CORS
+app.UseCors("AllowReact"); // Г‚ГЄГ«ГѕГ·Г ГҐГ¬ CORS
 
 app.UseExceptionHandler(appBuilder =>
 {
@@ -49,7 +51,7 @@ app.UseExceptionHandler(appBuilder =>
         var exception = context.Features.Get<IExceptionHandlerFeature>()?.Error;
         if (exception != null)
         {
-            Console.WriteLine($"Ошибка на сервере: {exception.Message}");
+            Console.WriteLine($"ГЋГёГЁГЎГЄГ  Г­Г  Г±ГҐГ°ГўГҐГ°ГҐ: {exception.Message}");
             Console.WriteLine($"StackTrace: {exception.StackTrace}");
         }
         await context.Response.WriteAsync("An unexpected error occurred.");

--- a/budget-tracker-backend/Services/Accounts/AccountManager.cs
+++ b/budget-tracker-backend/Services/Accounts/AccountManager.cs
@@ -1,0 +1,87 @@
+namespace budget_tracker_backend.Services.Accounts;
+
+using AutoMapper;
+using budget_tracker_backend.Data;
+using budget_tracker_backend.Dto.Accounts;
+using budget_tracker_backend.Exceptions;
+using budget_tracker_backend.Models;
+using Microsoft.EntityFrameworkCore;
+
+public class AccountManager : IAccountManager
+{
+    private readonly ApplicationDbContext _dbContext;
+    private readonly IMapper _mapper;
+
+    public AccountManager(ApplicationDbContext dbContext, IMapper mapper)
+    {
+        _dbContext = dbContext;
+        _mapper = mapper;
+    }
+
+    public async Task<IEnumerable<Account>> GetAllAsync(CancellationToken cancellationToken)
+    {
+        return await _dbContext.Accounts
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<Account?> GetByIdAsync(int id, CancellationToken cancellationToken)
+    {
+        return await _dbContext.Accounts.FindAsync(new object[] { id }, cancellationToken);
+    }
+
+    public async Task<Account> CreateAsync(CreateAccountDto dto, CancellationToken cancellationToken)
+    {
+        var entity = _mapper.Map<Account>(dto) ?? throw new CustomException("Cannot map CreateAccountDto to Account entity", StatusCodes.Status400BadRequest);
+
+        await _dbContext.Accounts.AddAsync(entity, cancellationToken);
+        var saved = await _dbContext.SaveChangesAsync(cancellationToken) > 0;
+        if (!saved)
+        {
+            throw new CustomException("Failed to create an account", StatusCodes.Status500InternalServerError);
+        }
+
+        return entity;
+    }
+
+    public async Task<Account> UpdateAsync(AccountDto dto, CancellationToken cancellationToken)
+    {
+        var existing = await _dbContext.Accounts.FindAsync(new object[] { dto.Id }, cancellationToken);
+        if (existing == null)
+        {
+            throw new CustomException("Account not found", StatusCodes.Status404NotFound);
+        }
+
+        existing.Title = dto.Title;
+        existing.Amount = dto.Amount;
+        existing.CurrencyId = dto.CurrencyId;
+        existing.Description = dto.Description;
+
+        _dbContext.Accounts.Update(existing);
+        var saved = await _dbContext.SaveChangesAsync(cancellationToken) > 0;
+        if (!saved)
+        {
+            throw new CustomException("Failed to update account", StatusCodes.Status500InternalServerError);
+        }
+
+        return existing;
+    }
+
+    public async Task<bool> DeleteAsync(int id, CancellationToken cancellationToken)
+    {
+        var account = await _dbContext.Accounts.FindAsync(new object[] { id }, cancellationToken);
+        if (account == null)
+        {
+            throw new CustomException("Account not found", StatusCodes.Status404NotFound);
+        }
+
+        _dbContext.Accounts.Remove(account);
+        var saved = await _dbContext.SaveChangesAsync(cancellationToken) > 0;
+        if (!saved)
+        {
+            throw new CustomException("Failed to delete account", StatusCodes.Status500InternalServerError);
+        }
+
+        return true;
+    }
+}

--- a/budget-tracker-backend/Services/Accounts/IAccountManager.cs
+++ b/budget-tracker-backend/Services/Accounts/IAccountManager.cs
@@ -1,0 +1,13 @@
+namespace budget_tracker_backend.Services.Accounts;
+
+using budget_tracker_backend.Dto.Accounts;
+using budget_tracker_backend.Models;
+
+public interface IAccountManager
+{
+    Task<IEnumerable<Account>> GetAllAsync(CancellationToken cancellationToken);
+    Task<Account?> GetByIdAsync(int id, CancellationToken cancellationToken);
+    Task<Account> CreateAsync(CreateAccountDto dto, CancellationToken cancellationToken);
+    Task<Account> UpdateAsync(AccountDto dto, CancellationToken cancellationToken);
+    Task<bool> DeleteAsync(int id, CancellationToken cancellationToken);
+}


### PR DESCRIPTION
## Summary
- add an `AccountManager` with interface to encapsulate account operations
- refactor account command/queries to use the new service
- register `AccountManager` in DI

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862a91d5b0c8330853602408747ca73