### PR TITLE
Add database context abstraction

### DIFF
--- a/budget-tracker-backend/Data/ApplicationDbContext.cs
+++ b/budget-tracker-backend/Data/ApplicationDbContext.cs
@@ -3,7 +3,7 @@ using budget_tracker_backend.Models;
 
 namespace budget_tracker_backend.Data;
 
-public class ApplicationDbContext : DbContext
+public class ApplicationDbContext : DbContext, IApplicationDbContext
 {
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) { }
 

--- a/budget-tracker-backend/Data/IApplicationDbContext.cs
+++ b/budget-tracker-backend/Data/IApplicationDbContext.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using budget_tracker_backend.Models;
+
+namespace budget_tracker_backend.Data;
+
+public interface IApplicationDbContext
+{
+    DbSet<Category> Categories { get; }
+    DbSet<Transaction> Transactions { get; }
+    DbSet<Account> Accounts { get; }
+    DbSet<BudgetPlan> BudgetPlans { get; }
+    DbSet<BudgetPlanItem> BudgetPlanItems { get; }
+    DbSet<Currency> Currencies { get; }
+    DbSet<Event> Events { get; }
+
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken);
+}

--- a/budget-tracker-backend/MediatR/BudgetPlanItems/Commands/Create/CreateBudgetPlanItemHandler.cs
+++ b/budget-tracker-backend/MediatR/BudgetPlanItems/Commands/Create/CreateBudgetPlanItemHandler.cs
@@ -9,10 +9,10 @@ namespace budget_tracker_backend.MediatR.BudgetPlanItems.Commands.Create;
 
 public class CreateBudgetPlanItemHandler : IRequestHandler<CreateBudgetPlanItemCommand, Result<BudgetPlanItemDto>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public CreateBudgetPlanItemHandler(ApplicationDbContext context, IMapper mapper)
+    public CreateBudgetPlanItemHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/BudgetPlanItems/Commands/Delete/DeleteBudgetPlanItemHandler.cs
+++ b/budget-tracker-backend/MediatR/BudgetPlanItems/Commands/Delete/DeleteBudgetPlanItemHandler.cs
@@ -6,9 +6,9 @@ namespace budget_tracker_backend.MediatR.BudgetPlanItems.Commands.Delete;
 
 public class DeleteBudgetPlanItemHandler : IRequestHandler<DeleteBudgetPlanItemCommand, Result<bool>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
 
-    public DeleteBudgetPlanItemHandler(ApplicationDbContext context)
+    public DeleteBudgetPlanItemHandler(IApplicationDbContext context)
     {
         _context = context;
     }

--- a/budget-tracker-backend/MediatR/BudgetPlanItems/Commands/Update/UpdateBudgetPlanItemHandler.cs
+++ b/budget-tracker-backend/MediatR/BudgetPlanItems/Commands/Update/UpdateBudgetPlanItemHandler.cs
@@ -8,10 +8,10 @@ namespace budget_tracker_backend.MediatR.BudgetPlanItems.Commands.Update;
 
 public class UpdateBudgetPlanItemHandler : IRequestHandler<UpdateBudgetPlanItemCommand, Result<BudgetPlanItemDto>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public UpdateBudgetPlanItemHandler(ApplicationDbContext context, IMapper mapper)
+    public UpdateBudgetPlanItemHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/BudgetPlanItems/Queries/GetAll/GetAllBudgetPlanItemsHandler.cs
+++ b/budget-tracker-backend/MediatR/BudgetPlanItems/Queries/GetAll/GetAllBudgetPlanItemsHandler.cs
@@ -9,10 +9,10 @@ namespace budget_tracker_backend.MediatR.BudgetPlanItems.Queries.GetAll;
 
 public class GetAllBudgetPlanItemsHandler : IRequestHandler<GetAllBudgetPlanItemsQuery, Result<IEnumerable<BudgetPlanItemDto>>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public GetAllBudgetPlanItemsHandler(ApplicationDbContext context, IMapper mapper)
+    public GetAllBudgetPlanItemsHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/BudgetPlanItems/Queries/GetById/GetBudgetPlanItemByIdHandler.cs
+++ b/budget-tracker-backend/MediatR/BudgetPlanItems/Queries/GetById/GetBudgetPlanItemByIdHandler.cs
@@ -8,10 +8,10 @@ namespace budget_tracker_backend.MediatR.BudgetPlanItems.Queries.GetById;
 
 public class GetBudgetPlanItemByIdHandler : IRequestHandler<GetBudgetPlanItemByIdQuery, Result<BudgetPlanItemDto>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public GetBudgetPlanItemByIdHandler(ApplicationDbContext context, IMapper mapper)
+    public GetBudgetPlanItemByIdHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/BudgetPlanItems/Queries/GetByPlanId/GetAllBudgetPlanItemsByPlanIdHandler.cs
+++ b/budget-tracker-backend/MediatR/BudgetPlanItems/Queries/GetByPlanId/GetAllBudgetPlanItemsByPlanIdHandler.cs
@@ -10,10 +10,10 @@ namespace budget_tracker_backend.MediatR.BudgetPlanItems.Queries.GetByPlanId;
 
 public class GetAllBudgetPlanItemsByPlanIdHandler : IRequestHandler<GetAllBudgetPlanItemsByPlanIdQuery, Result<IEnumerable<BudgetPlanItemDto>>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public GetAllBudgetPlanItemsByPlanIdHandler(ApplicationDbContext context, IMapper mapper)
+    public GetAllBudgetPlanItemsByPlanIdHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/BudgetPlans/Commands/Create/CreateBudgetPlanHandler.cs
+++ b/budget-tracker-backend/MediatR/BudgetPlans/Commands/Create/CreateBudgetPlanHandler.cs
@@ -9,10 +9,10 @@ namespace budget_tracker_backend.MediatR.BudgetPlans.Commands.Create;
 
 public class CreateBudgetPlanHandler : IRequestHandler<CreateBudgetPlanCommand, Result<BudgetPlanDto>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public CreateBudgetPlanHandler(ApplicationDbContext context, IMapper mapper)
+    public CreateBudgetPlanHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/BudgetPlans/Commands/Delete/DeleteBudgetPlanHandler.cs
+++ b/budget-tracker-backend/MediatR/BudgetPlans/Commands/Delete/DeleteBudgetPlanHandler.cs
@@ -6,9 +6,9 @@ namespace budget_tracker_backend.MediatR.BudgetPlans.Commands.Delete;
 
 public class DeleteBudgetPlanHandler : IRequestHandler<DeleteBudgetPlanCommand, Result<bool>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
 
-    public DeleteBudgetPlanHandler(ApplicationDbContext context)
+    public DeleteBudgetPlanHandler(IApplicationDbContext context)
     {
         _context = context;
     }

--- a/budget-tracker-backend/MediatR/BudgetPlans/Commands/Update/UpdateBudgetPlanHandler.cs
+++ b/budget-tracker-backend/MediatR/BudgetPlans/Commands/Update/UpdateBudgetPlanHandler.cs
@@ -8,10 +8,10 @@ namespace budget_tracker_backend.MediatR.BudgetPlans.Commands.Update;
 
 public class UpdateBudgetPlanHandler : IRequestHandler<UpdateBudgetPlanCommand, Result<BudgetPlanDto>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public UpdateBudgetPlanHandler(ApplicationDbContext context, IMapper mapper)
+    public UpdateBudgetPlanHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/BudgetPlans/Queries/GetAll/GetAllBudgetPlansHandler.cs
+++ b/budget-tracker-backend/MediatR/BudgetPlans/Queries/GetAll/GetAllBudgetPlansHandler.cs
@@ -10,10 +10,10 @@ namespace budget_tracker_backend.MediatR.BudgetPlans.Queries.GetAll;
 public class GetAllBudgetPlansHandler
     : IRequestHandler<GetAllBudgetPlansQuery, Result<IEnumerable<BudgetPlanDto>>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public GetAllBudgetPlansHandler(ApplicationDbContext context, IMapper mapper)
+    public GetAllBudgetPlansHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/BudgetPlans/Queries/GetById/GetBudgetPlanByIdHandler.cs
+++ b/budget-tracker-backend/MediatR/BudgetPlans/Queries/GetById/GetBudgetPlanByIdHandler.cs
@@ -9,10 +9,10 @@ namespace budget_tracker_backend.MediatR.BudgetPlans.Queries.GetById;
 public class GetBudgetPlanByIdHandler
     : IRequestHandler<GetBudgetPlanByIdQuery, Result<BudgetPlanDto>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public GetBudgetPlanByIdHandler(ApplicationDbContext context, IMapper mapper)
+    public GetBudgetPlanByIdHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Categories/Commands/Create/CreateCategoryHandler.cs
+++ b/budget-tracker-backend/MediatR/Categories/Commands/Create/CreateCategoryHandler.cs
@@ -10,10 +10,10 @@ namespace budget_tracker_backend.MediatR.Categories.Commands.Create;
 
 public class CreateCategoryHandler : IRequestHandler<CreateCategoryCommand, Result<CategoryDto>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public CreateCategoryHandler(ApplicationDbContext context, IMapper mapper)
+    public CreateCategoryHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Categories/Commands/Delete/DeleteCategoryHandler.cs
+++ b/budget-tracker-backend/MediatR/Categories/Commands/Delete/DeleteCategoryHandler.cs
@@ -8,9 +8,9 @@ namespace budget_tracker_backend.MediatR.Categories.Commands.Delete;
 
 public class DeleteCategoryHandler : IRequestHandler<DeleteCategoryCommand, Result<bool>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
 
-    public DeleteCategoryHandler(ApplicationDbContext context)
+    public DeleteCategoryHandler(IApplicationDbContext context)
     {
         _context = context;
     }

--- a/budget-tracker-backend/MediatR/Categories/Commands/Update/UpdateCategoryHandler.cs
+++ b/budget-tracker-backend/MediatR/Categories/Commands/Update/UpdateCategoryHandler.cs
@@ -10,10 +10,10 @@ namespace budget_tracker_backend.MediatR.Categories.Commands.Update;
 
 public class UpdateCategoryHandler : IRequestHandler<UpdateCategoryCommand, Result<CategoryDto>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public UpdateCategoryHandler(ApplicationDbContext context, IMapper mapper)
+    public UpdateCategoryHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Categories/Queries/GetAll/GetAllCategoriesHandler.cs
+++ b/budget-tracker-backend/MediatR/Categories/Queries/GetAll/GetAllCategoriesHandler.cs
@@ -10,10 +10,10 @@ namespace budget_tracker_backend.MediatR.Categories.Queries.GetAll;
 public class GetAllCategoriesHandler
     : IRequestHandler<GetAllCategoriesQuery, Result<IEnumerable<CategoryDto>>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public GetAllCategoriesHandler(ApplicationDbContext context, IMapper mapper)
+    public GetAllCategoriesHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Categories/Queries/GetById/GetCategoryByIdHandler.cs
+++ b/budget-tracker-backend/MediatR/Categories/Queries/GetById/GetCategoryByIdHandler.cs
@@ -11,10 +11,10 @@ namespace budget_tracker_backend.MediatR.Categories.Queries.GetById;
 public class GetCategoryByIdHandler
     : IRequestHandler<GetCategoryByIdQuery, Result<CategoryDto>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public GetCategoryByIdHandler(ApplicationDbContext context, IMapper mapper)
+    public GetCategoryByIdHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Categories/Queries/GetCategoriesByType/GetCategoriesByTypeHandler.cs
+++ b/budget-tracker-backend/MediatR/Categories/Queries/GetCategoriesByType/GetCategoriesByTypeHandler.cs
@@ -12,10 +12,10 @@ namespace budget_tracker_backend.MediatR.Categories.Queries.GetByType;
 public class GetCategoriesByTypeHandler
     : IRequestHandler<GetCategoriesByTypeQuery, Result<IEnumerable<CategoryDto>>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public GetCategoriesByTypeHandler(ApplicationDbContext context, IMapper mapper)
+    public GetCategoriesByTypeHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Components/EditPlanModal/GetEditPlanModalHandler.cs
+++ b/budget-tracker-backend/MediatR/Components/EditPlanModal/GetEditPlanModalHandler.cs
@@ -12,10 +12,10 @@ namespace budget_tracker_backend.MediatR.Components.EditPlanModal;
 
 public class GetEditPlanModalHandler : IRequestHandler<GetEditPlanModalQuery, Result<EditPlanModalDto>>
 {
-    private readonly ApplicationDbContext _ctx;
+    private readonly IApplicationDbContext _ctx;
     private readonly IMapper _mapper;
 
-    public GetEditPlanModalHandler(ApplicationDbContext ctx, IMapper mapper)
+    public GetEditPlanModalHandler(IApplicationDbContext ctx, IMapper mapper)
     {
         _ctx = ctx;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Components/ExpenseModal/GetExpenseModalHandler.cs
+++ b/budget-tracker-backend/MediatR/Components/ExpenseModal/GetExpenseModalHandler.cs
@@ -14,10 +14,10 @@ namespace budget_tracker_backend.MediatR.Components.ExpenseModal;
 
 public class GetExpenseModalHandler : IRequestHandler<GetExpenseModalQuery, Result<ExpenseModalDto>>
 {
-    private readonly ApplicationDbContext _ctx;
+    private readonly IApplicationDbContext _ctx;
     private readonly IMapper _mapper;
 
-    public GetExpenseModalHandler(ApplicationDbContext ctx, IMapper mapper)
+    public GetExpenseModalHandler(IApplicationDbContext ctx, IMapper mapper)
     {
         _ctx = ctx;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Components/IncomeModal/GetIncomeModalHandler.cs
+++ b/budget-tracker-backend/MediatR/Components/IncomeModal/GetIncomeModalHandler.cs
@@ -13,10 +13,10 @@ namespace budget_tracker_backend.MediatR.Components.IncomeModal;
 
 public class GetIncomeModalHandler : IRequestHandler<GetIncomeModalQuery, Result<IncomeModalDto>>
 {
-    private readonly ApplicationDbContext _ctx;
+    private readonly IApplicationDbContext _ctx;
     private readonly IMapper _mapper;
 
-    public GetIncomeModalHandler(ApplicationDbContext ctx, IMapper mapper)
+    public GetIncomeModalHandler(IApplicationDbContext ctx, IMapper mapper)
     {
         _ctx = ctx;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Components/ManageAccounts/GetManageAccountsHandler.cs
+++ b/budget-tracker-backend/MediatR/Components/ManageAccounts/GetManageAccountsHandler.cs
@@ -10,10 +10,10 @@ namespace budget_tracker_backend.MediatR.Components.ManageAccounts;
 
 public class GetManageAccountsHandler : IRequestHandler<GetManageAccountsQuery, Result<ManageAccountsDto>>
 {
-    private readonly ApplicationDbContext _ctx;
+    private readonly IApplicationDbContext _ctx;
     private readonly IMapper _mapper;
 
-    public GetManageAccountsHandler(ApplicationDbContext ctx, IMapper mapper)
+    public GetManageAccountsHandler(IApplicationDbContext ctx, IMapper mapper)
     {
         _ctx = ctx;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Components/ManageCategories/GetManageCategoriesHandler.cs
+++ b/budget-tracker-backend/MediatR/Components/ManageCategories/GetManageCategoriesHandler.cs
@@ -11,10 +11,10 @@ namespace budget_tracker_backend.MediatR.Components.ManageCategories;
 
 public class GetManageCategoriesHandler : IRequestHandler<GetManageCategoriesQuery, Result<ManageCategoriesDto>>
 {
-    private readonly ApplicationDbContext _ctx;
+    private readonly IApplicationDbContext _ctx;
     private readonly IMapper _mapper;
 
-    public GetManageCategoriesHandler(ApplicationDbContext ctx, IMapper mapper)
+    public GetManageCategoriesHandler(IApplicationDbContext ctx, IMapper mapper)
     {
         _ctx = ctx;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Components/TransferModal/GetTransferModalHandler.cs
+++ b/budget-tracker-backend/MediatR/Components/TransferModal/GetTransferModalHandler.cs
@@ -13,10 +13,10 @@ namespace budget_tracker_backend.MediatR.Components.TransferModal;
 
 public class GetTransferModalHandler : IRequestHandler<GetTransferModalQuery, Result<TransferModalDto>>
 {
-    private readonly ApplicationDbContext _ctx;
+    private readonly IApplicationDbContext _ctx;
     private readonly IMapper _mapper;
 
-    public GetTransferModalHandler(ApplicationDbContext ctx, IMapper mapper)
+    public GetTransferModalHandler(IApplicationDbContext ctx, IMapper mapper)
     {
         _ctx = ctx;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Currencies/Commands/Create/CreateCurrencyHandler.cs
+++ b/budget-tracker-backend/MediatR/Currencies/Commands/Create/CreateCurrencyHandler.cs
@@ -10,10 +10,10 @@ namespace budget_tracker_backend.MediatR.Currencies.Commands.Create;
 public class CreateCurrencyHandler
     : IRequestHandler<CreateCurrencyCommand, Result<CurrencyDto>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public CreateCurrencyHandler(ApplicationDbContext context, IMapper mapper)
+    public CreateCurrencyHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Currencies/Commands/Delete/DeleteCurrencyHandler.cs
+++ b/budget-tracker-backend/MediatR/Currencies/Commands/Delete/DeleteCurrencyHandler.cs
@@ -7,9 +7,9 @@ namespace budget_tracker_backend.MediatR.Currencies.Commands.Delete;
 
 public class DeleteCurrencyHandler : IRequestHandler<DeleteCurrencyCommand, Result<bool>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
 
-    public DeleteCurrencyHandler(ApplicationDbContext context)
+    public DeleteCurrencyHandler(IApplicationDbContext context)
     {
         _context = context;
     }

--- a/budget-tracker-backend/MediatR/Currencies/Commands/Update/UpdateCurrencyHandler.cs
+++ b/budget-tracker-backend/MediatR/Currencies/Commands/Update/UpdateCurrencyHandler.cs
@@ -9,10 +9,10 @@ namespace budget_tracker_backend.MediatR.Currencies.Commands.Update;
 
 public class UpdateCurrencyHandler : IRequestHandler<UpdateCurrencyCommand, Result<CurrencyDto>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public UpdateCurrencyHandler(ApplicationDbContext context, IMapper mapper)
+    public UpdateCurrencyHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Currencies/Queries/GetAll/GetAllCurrenciesHandler.cs
+++ b/budget-tracker-backend/MediatR/Currencies/Queries/GetAll/GetAllCurrenciesHandler.cs
@@ -9,10 +9,10 @@ namespace budget_tracker_backend.MediatR.Currencies.Queries.GetAll;
 
 public class GetAllCurrenciesHandler : IRequestHandler<GetAllCurrenciesQuery, Result<IEnumerable<CurrencyDto>>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public GetAllCurrenciesHandler(ApplicationDbContext context, IMapper mapper)
+    public GetAllCurrenciesHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Currencies/Queries/GetById/GetCurrencyByIdHandler.cs
+++ b/budget-tracker-backend/MediatR/Currencies/Queries/GetById/GetCurrencyByIdHandler.cs
@@ -9,10 +9,10 @@ namespace budget_tracker_backend.MediatR.Currencies.Queries.GetById;
 
 public class GetCurrencyByIdHandler : IRequestHandler<GetCurrencyByIdQuery, Result<CurrencyDto>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public GetCurrencyByIdHandler(ApplicationDbContext context, IMapper mapper)
+    public GetCurrencyByIdHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Events/Commands/Create/CreateEventHandler.cs
+++ b/budget-tracker-backend/MediatR/Events/Commands/Create/CreateEventHandler.cs
@@ -9,10 +9,10 @@ namespace budget_tracker_backend.MediatR.Events.Commands.Create;
 
 public class CreateEventHandler : IRequestHandler<CreateEventCommand, Result<EventDto>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public CreateEventHandler(ApplicationDbContext context, IMapper mapper)
+    public CreateEventHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Events/Commands/Delete/DeleteEventHandler.cs
+++ b/budget-tracker-backend/MediatR/Events/Commands/Delete/DeleteEventHandler.cs
@@ -7,9 +7,9 @@ namespace budget_tracker_backend.MediatR.Events.Commands.Delete;
 
 public class DeleteEventHandler : IRequestHandler<DeleteEventCommand, Result<bool>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
 
-    public DeleteEventHandler(ApplicationDbContext context)
+    public DeleteEventHandler(IApplicationDbContext context)
     {
         _context = context;
     }

--- a/budget-tracker-backend/MediatR/Events/Commands/Update/UpdateEventHandler.cs
+++ b/budget-tracker-backend/MediatR/Events/Commands/Update/UpdateEventHandler.cs
@@ -9,10 +9,10 @@ namespace budget_tracker_backend.MediatR.Events.Commands.Update;
 
 public class UpdateEventHandler : IRequestHandler<UpdateEventCommand, Result<EventDto>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public UpdateEventHandler(ApplicationDbContext context, IMapper mapper)
+    public UpdateEventHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Events/Queries/GetAll/GetAllEventsHandler.cs
+++ b/budget-tracker-backend/MediatR/Events/Queries/GetAll/GetAllEventsHandler.cs
@@ -9,10 +9,10 @@ namespace budget_tracker_backend.MediatR.Events.Queries.GetAll;
 
 public class GetAllEventsHandler : IRequestHandler<GetAllEventsQuery, Result<IEnumerable<EventDto>>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public GetAllEventsHandler(ApplicationDbContext context, IMapper mapper)
+    public GetAllEventsHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Events/Queries/GetById/GetEventByIdHandler.cs
+++ b/budget-tracker-backend/MediatR/Events/Queries/GetById/GetEventByIdHandler.cs
@@ -9,10 +9,10 @@ namespace budget_tracker_backend.MediatR.Events.Queries.GetById;
 
 public class GetEventByIdHandler : IRequestHandler<GetEventByIdQuery, Result<EventDto>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public GetEventByIdHandler(ApplicationDbContext context, IMapper mapper)
+    public GetEventByIdHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Events/Queries/GetByIdWithTransactions/GetEventWithTransactionsHandler.cs
+++ b/budget-tracker-backend/MediatR/Events/Queries/GetByIdWithTransactions/GetEventWithTransactionsHandler.cs
@@ -10,10 +10,10 @@ namespace budget_tracker_backend.MediatR.Events.Queries.GetByIdWithTransactions;
 
 public class GetEventWithTransactionsHandler : IRequestHandler<GetEventWithTransactionsQuery, Result<EventWithTransactionsDto>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public GetEventWithTransactionsHandler(ApplicationDbContext context, IMapper mapper)
+    public GetEventWithTransactionsHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Pages/BudgetPlanPage/GetBudgetPlanPageHandler.cs
+++ b/budget-tracker-backend/MediatR/Pages/BudgetPlanPage/GetBudgetPlanPageHandler.cs
@@ -10,10 +10,10 @@ namespace budget_tracker_backend.MediatR.Pages.BudgetPlanPage;
 
 public class GetBudgetPlanPageHandler : IRequestHandler<GetBudgetPlanPageQuery, Result<BudgetPlanPageDto>>
 {
-    private readonly ApplicationDbContext _ctx;
+    private readonly IApplicationDbContext _ctx;
     private readonly IMapper _mapper;
 
-    public GetBudgetPlanPageHandler(ApplicationDbContext ctx, IMapper mapper)
+    public GetBudgetPlanPageHandler(IApplicationDbContext ctx, IMapper mapper)
     {
         _ctx = ctx; _mapper = mapper;
     }

--- a/budget-tracker-backend/MediatR/Pages/Dashboard/GetDashboardHandler.cs
+++ b/budget-tracker-backend/MediatR/Pages/Dashboard/GetDashboardHandler.cs
@@ -10,10 +10,10 @@ namespace budget_tracker_backend.MediatR.Pages.Dashboard;
 
 public class GetDashboardHandler : IRequestHandler<GetDashboardQuery, Result<DashboardDto>>
 {
-    private readonly ApplicationDbContext _ctx;
+    private readonly IApplicationDbContext _ctx;
     private readonly IMapper _mapper;
 
-    public GetDashboardHandler(ApplicationDbContext ctx, IMapper mapper)
+    public GetDashboardHandler(IApplicationDbContext ctx, IMapper mapper)
     {
         _ctx = ctx; _mapper = mapper;
     }

--- a/budget-tracker-backend/MediatR/Pages/ExpensesByMonth/GetExpensesByMonthHandler.cs
+++ b/budget-tracker-backend/MediatR/Pages/ExpensesByMonth/GetExpensesByMonthHandler.cs
@@ -11,10 +11,10 @@ namespace budget_tracker_backend.MediatR.Pages.ExpensesByMonth;
 public class GetExpensesByMonthHandler
     : IRequestHandler<GetExpensesByMonthQuery, Result<ExpensesByMonthDto>>
 {
-    private readonly ApplicationDbContext _ctx;
+    private readonly IApplicationDbContext _ctx;
     private readonly IMapper _mapper;
 
-    public GetExpensesByMonthHandler(ApplicationDbContext ctx, IMapper mapper)
+    public GetExpensesByMonthHandler(IApplicationDbContext ctx, IMapper mapper)
     {
         _ctx = ctx; _mapper = mapper;
     }

--- a/budget-tracker-backend/MediatR/Pages/IncomesByMonth/GetIncomesByMonthHandler.cs
+++ b/budget-tracker-backend/MediatR/Pages/IncomesByMonth/GetIncomesByMonthHandler.cs
@@ -11,10 +11,10 @@ namespace budget_tracker_backend.MediatR.Pages.IncomesByMonth;
 public class GetIncomesByMonthHandler
     : IRequestHandler<GetIncomesByMonthQuery, Result<IncomesByMonthDto>>
 {
-    private readonly ApplicationDbContext _ctx;
+    private readonly IApplicationDbContext _ctx;
     private readonly IMapper _mapper;
 
-    public GetIncomesByMonthHandler(ApplicationDbContext ctx, IMapper mapper)
+    public GetIncomesByMonthHandler(IApplicationDbContext ctx, IMapper mapper)
     {
         _ctx = ctx; _mapper = mapper;
     }

--- a/budget-tracker-backend/MediatR/Pages/MonthlyReport/GetMonthlyReportHandler.cs
+++ b/budget-tracker-backend/MediatR/Pages/MonthlyReport/GetMonthlyReportHandler.cs
@@ -9,9 +9,9 @@ namespace budget_tracker_backend.MediatR.Pages.MonthlyReport;
 
 public class GetMonthlyReportHandler : IRequestHandler<GetMonthlyReportQuery, Result<MonthlyReportDto>>
 {
-    private readonly ApplicationDbContext _ctx;
+    private readonly IApplicationDbContext _ctx;
 
-    public GetMonthlyReportHandler(ApplicationDbContext ctx)
+    public GetMonthlyReportHandler(IApplicationDbContext ctx)
     {
         _ctx = ctx;
     }

--- a/budget-tracker-backend/MediatR/Pages/TransfersByMonth/GetTransfersByMonthHandler.cs
+++ b/budget-tracker-backend/MediatR/Pages/TransfersByMonth/GetTransfersByMonthHandler.cs
@@ -11,10 +11,10 @@ namespace budget_tracker_backend.MediatR.Pages.TransfersByMonth;
 public class GetTransfersByMonthHandler
     : IRequestHandler<GetTransfersByMonthQuery, Result<TransfersByMonthDto>>
 {
-    private readonly ApplicationDbContext _ctx;
+    private readonly IApplicationDbContext _ctx;
     private readonly IMapper _mapper;
 
-    public GetTransfersByMonthHandler(ApplicationDbContext ctx, IMapper mapper)
+    public GetTransfersByMonthHandler(IApplicationDbContext ctx, IMapper mapper)
     {
         _ctx = ctx; _mapper = mapper;
     }

--- a/budget-tracker-backend/MediatR/Transactions/Commands/Create/CreateTransactionHandler.cs
+++ b/budget-tracker-backend/MediatR/Transactions/Commands/Create/CreateTransactionHandler.cs
@@ -9,10 +9,10 @@ using MediatR;
 
 public class CreateTransactionHandler : IRequestHandler<CreateTransactionCommand, Result<TransactionDto>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public CreateTransactionHandler(ApplicationDbContext context, IMapper mapper)
+    public CreateTransactionHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Transactions/Commands/Delete/DeleteTransactionHandler.cs
+++ b/budget-tracker-backend/MediatR/Transactions/Commands/Delete/DeleteTransactionHandler.cs
@@ -10,9 +10,9 @@ namespace budget_tracker_backend.MediatR.Transactions.Commands.Delete;
 public class DeleteTransactionHandler
     : IRequestHandler<DeleteTransactionCommand, Result<bool>>
 {
-    private readonly ApplicationDbContext _ctx;
+    private readonly IApplicationDbContext _ctx;
 
-    public DeleteTransactionHandler(ApplicationDbContext ctx) => _ctx = ctx;
+    public DeleteTransactionHandler(IApplicationDbContext ctx) => _ctx = ctx;
 
     public async Task<Result<bool>> Handle(DeleteTransactionCommand request, CancellationToken ct)
     {

--- a/budget-tracker-backend/MediatR/Transactions/Commands/Update/UpdateTransactionHandler.cs
+++ b/budget-tracker-backend/MediatR/Transactions/Commands/Update/UpdateTransactionHandler.cs
@@ -13,10 +13,10 @@ namespace budget_tracker_backend.MediatR.Transactions.Commands.Update;
 public class UpdateTransactionHandler
     : IRequestHandler<UpdateTransactionCommand, Result<TransactionDto>>
 {
-    private readonly ApplicationDbContext _ctx;
+    private readonly IApplicationDbContext _ctx;
     private readonly IMapper _mapper;
 
-    public UpdateTransactionHandler(ApplicationDbContext ctx, IMapper mapper)
+    public UpdateTransactionHandler(IApplicationDbContext ctx, IMapper mapper)
     {
         _ctx = ctx;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Transactions/Queries/GetAll/GetAllTransactionsHandler.cs
+++ b/budget-tracker-backend/MediatR/Transactions/Queries/GetAll/GetAllTransactionsHandler.cs
@@ -9,10 +9,10 @@ namespace budget_tracker_backend.MediatR.Transactions.Queries.GetAll;
 
 public class GetAllTransactionsHandler : IRequestHandler<GetAllTransactionsQuery, Result<IEnumerable<TransactionDto>>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public GetAllTransactionsHandler(ApplicationDbContext context, IMapper mapper)
+    public GetAllTransactionsHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Transactions/Queries/GetByBudgetPlan/GetTransactionsByBudgetPlanIdHandler.cs
+++ b/budget-tracker-backend/MediatR/Transactions/Queries/GetByBudgetPlan/GetTransactionsByBudgetPlanIdHandler.cs
@@ -11,10 +11,10 @@ public class GetTransactionsByBudgetPlanIdHandler
     : IRequestHandler<GetTransactionsByBudgetPlanIdQuery,
                       Result<IEnumerable<TransactionDto>>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public GetTransactionsByBudgetPlanIdHandler(ApplicationDbContext context, IMapper mapper)
+    public GetTransactionsByBudgetPlanIdHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Transactions/Queries/GetByEvent/GetAllTransactionsByEventHandler.cs
+++ b/budget-tracker-backend/MediatR/Transactions/Queries/GetByEvent/GetAllTransactionsByEventHandler.cs
@@ -10,10 +10,10 @@ namespace budget_tracker_backend.MediatR.Transactions.Queries.GetByEvent;
 
 public class GetAllTransactionsByEventHandler : IRequestHandler<GetAllTransactionsByEventQuery, Result<IEnumerable<TransactionDto>>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public GetAllTransactionsByEventHandler(ApplicationDbContext context, IMapper mapper)
+    public GetAllTransactionsByEventHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Transactions/Queries/GetById/GetTransactionByIdHandler.cs
+++ b/budget-tracker-backend/MediatR/Transactions/Queries/GetById/GetTransactionByIdHandler.cs
@@ -9,10 +9,10 @@ namespace budget_tracker_backend.MediatR.Transactions.Queries.GetById;
 
 public class GetTransactionByIdHandler : IRequestHandler<GetTransactionByIdQuery, Result<TransactionDto>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public GetTransactionByIdHandler(ApplicationDbContext context, IMapper mapper)
+    public GetTransactionByIdHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/MediatR/Transactions/Queries/GetTransactions/GetTransactionsHandler.cs
+++ b/budget-tracker-backend/MediatR/Transactions/Queries/GetTransactions/GetTransactionsHandler.cs
@@ -10,10 +10,10 @@ namespace budget_tracker_backend.MediatR.Transactions.Queries.GetTransactions;
 
 public class GetTransactionsHandler : IRequestHandler<GetTransactionsQuery, Result<IEnumerable<TransactionDto>>>
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IApplicationDbContext _context;
     private readonly IMapper _mapper;
 
-    public GetTransactionsHandler(ApplicationDbContext context, IMapper mapper)
+    public GetTransactionsHandler(IApplicationDbContext context, IMapper mapper)
     {
         _context = context;
         _mapper = mapper;

--- a/budget-tracker-backend/Program.cs
+++ b/budget-tracker-backend/Program.cs
@@ -12,6 +12,8 @@ builder.Services.AddScoped<IAccountManager, AccountManager>();
 // Ïîäêëþ÷àåì EF Core è MS SQL
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+builder.Services.AddScoped<IApplicationDbContext>(sp =>
+    sp.GetRequiredService<ApplicationDbContext>());
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();

--- a/budget-tracker-backend/Services/Accounts/AccountManager.cs
+++ b/budget-tracker-backend/Services/Accounts/AccountManager.cs
@@ -9,10 +9,10 @@ using Microsoft.EntityFrameworkCore;
 
 public class AccountManager : IAccountManager
 {
-    private readonly ApplicationDbContext _dbContext;
+    private readonly IApplicationDbContext _dbContext;
     private readonly IMapper _mapper;
 
-    public AccountManager(ApplicationDbContext dbContext, IMapper mapper)
+    public AccountManager(IApplicationDbContext dbContext, IMapper mapper)
     {
         _dbContext = dbContext;
         _mapper = mapper;


### PR DESCRIPTION
## Summary
- define `IApplicationDbContext` interface
- implement interface in `ApplicationDbContext`
- register the interface in dependency injection
- use the abstraction across handlers and services

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b69386188330a1a98919b6a335cf