### PR TITLE
Fix spent calculation and use services in PageManager

### DIFF
--- a/budget-tracker-backend/Services/BudgetPlanItems/BudgetPlanItemManager.cs
+++ b/budget-tracker-backend/Services/BudgetPlanItems/BudgetPlanItemManager.cs
@@ -34,6 +34,8 @@ public class BudgetPlanItemManager : IBudgetPlanItemManager
     public async Task<IEnumerable<BudgetPlanItem>> GetByPlanIdAsync(int planId, CancellationToken cancellationToken)
     {
         return await _context.BudgetPlanItems
+            .Include(i => i.Category)
+            .Include(i => i.Currency)
             .Where(i => i.BudgetPlanId == planId)
             .AsNoTracking()
             .ToListAsync(cancellationToken);


### PR DESCRIPTION
## Summary
- use `IBudgetPlanManager`, `IBudgetPlanItemManager` and `ITransactionManager` in `PageManager`
- query plan items via manager with category/currency includes
- calculate spent per category using transactions that belong to the plan

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d9dded948330924f8851f36365ae