### PR TITLE
Add generated UnicCode to transactions

### DIFF
--- a/budget-tracker-backend/Data/ApplicationDbContext.cs
+++ b/budget-tracker-backend/Data/ApplicationDbContext.cs
@@ -35,6 +35,13 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
             .Property(t => t.Amount)
             .HasColumnType("decimal(18,4)");
 
+        modelBuilder.Entity<Transaction>()
+            .Property(t => t.UnicCode)
+            .HasMaxLength(64);
+
+        modelBuilder.Entity<Transaction>()
+            .HasIndex(t => t.UnicCode);
+
         // 1. Prohibit cascading deletion Event → Transaction
         modelBuilder.Entity<Transaction>()
             .HasOne(t => t.Event)

--- a/budget-tracker-backend/Dto/Transactions/TransactionDto.cs
+++ b/budget-tracker-backend/Dto/Transactions/TransactionDto.cs
@@ -14,6 +14,7 @@ public class TransactionDto
     public int CurrencyId { get; set; }
     public int? CategoryId { get; set; }
     public DateTime Date { get; set; }
+    public string UnicCode { get; set; } = null!;
     public TransactionCategoryType? Type { get; set; }
     public string? Description { get; set; }
 }

--- a/budget-tracker-backend/Mapping/TransactionProfile.cs
+++ b/budget-tracker-backend/Mapping/TransactionProfile.cs
@@ -10,9 +10,11 @@ public class TransactionProfile : Profile
     {
         CreateMap<Transaction, TransactionDto>();
 
-        CreateMap<CreateTransactionDto, Transaction>();
+        CreateMap<CreateTransactionDto, Transaction>()
+            .ForMember(d => d.UnicCode, o => o.Ignore());
 
-        CreateMap<TransactionDto, Transaction>();
+        CreateMap<TransactionDto, Transaction>()
+            .ForMember(d => d.UnicCode, o => o.Ignore());
 
         CreateMap<UpdateTransactionDto, Transaction>()
             .ForAllMembers(opts => opts.Condition(

--- a/budget-tracker-backend/Models/Transaction.cs
+++ b/budget-tracker-backend/Models/Transaction.cs
@@ -13,6 +13,7 @@ public class Transaction
     public int CurrencyId { get; set; }
     public int? CategoryId { get; set; }
     public DateTime Date { get; set; }
+    public string UnicCode { get; set; } = null!;
 
     public int? AccountFrom { get; set; }
     public int? AccountTo { get; set; } 


### PR DESCRIPTION
## Summary
- add `UnicCode` field to `Transaction`
- expose the field via `TransactionDto`
- ignore it when mapping from DTOs
- compute the code during create/update operations
- remove generated migration files per user request

## Testing
- `dotnet build budget-tracker-backend.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887ab6dbbc4833094743342c1b021af