### PR TITLE
Add transaction preparation endpoint

### DIFF
--- a/budget-tracker-backend/Dto/Transactions/ImportTransactionDto.cs
+++ b/budget-tracker-backend/Dto/Transactions/ImportTransactionDto.cs
@@ -1,0 +1,20 @@
+using budget_tracker_backend.Models.Enums;
+
+namespace budget_tracker_backend.Dto.Transactions;
+
+/// <summary>
+/// DTO used to import raw transaction data. Currency is specified as code string.
+/// Other relational identifiers may be missing.
+/// </summary>
+public class ImportTransactionDto
+{
+    public string Title { get; set; } = null!;
+    public decimal Amount { get; set; }
+    public string Currency { get; set; } = null!;
+    public int? AccountFrom { get; set; }
+    public int? AccountTo { get; set; }
+    public DateTime Date { get; set; }
+    public TransactionCategoryType Type { get; set; }
+    public string? Description { get; set; }
+    public string? AuthCode { get; set; }
+}

--- a/budget-tracker-backend/Dto/Transactions/PreparedTransactionDto.cs
+++ b/budget-tracker-backend/Dto/Transactions/PreparedTransactionDto.cs
@@ -1,0 +1,22 @@
+using budget_tracker_backend.Models.Enums;
+
+namespace budget_tracker_backend.Dto.Transactions;
+
+/// <summary>
+/// Transaction DTO with fields filled from existing data.
+/// </summary>
+public class PreparedTransactionDto
+{
+    public string? Title { get; set; }
+    public decimal? Amount { get; set; }
+    public int? AccountFrom { get; set; }
+    public int? AccountTo { get; set; }
+    public int? EventId { get; set; }
+    public int? BudgetPlanId { get; set; }
+    public int? CurrencyId { get; set; }
+    public int? CategoryId { get; set; }
+    public DateTime? Date { get; set; }
+    public TransactionCategoryType? Type { get; set; }
+    public string? Description { get; set; }
+    public string? AuthCode { get; set; }
+}

--- a/budget-tracker-backend/Services/Transactions/ITransactionManager.cs
+++ b/budget-tracker-backend/Services/Transactions/ITransactionManager.cs
@@ -29,4 +29,11 @@ public interface ITransactionManager
     Task<Transaction> CreateAsync(CreateTransactionDto dto, CancellationToken cancellationToken);
     Task<Transaction> UpdateAsync(UpdateTransactionDto dto, CancellationToken cancellationToken);
     Task<bool> DeleteAsync(int id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Prepare incoming transactions by filling missing fields.
+    /// </summary>
+    Task<IEnumerable<PreparedTransactionDto>> PrepareAsync(
+        IEnumerable<ImportTransactionDto> source,
+        CancellationToken cancellationToken);
 }


### PR DESCRIPTION
## Summary
- add DTOs for importing raw transactions and prepared results
- extend transaction manager to prepare imported transactions
- expose new `POST /api/Transactions/prepare` endpoint

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68889558acac833096f834ea408a17b6