### PR TITLE
Add JWT authentication and secure controllers

### DIFF
--- a/budget-tracker-backend/Controllers/AccountsController.cs
+++ b/budget-tracker-backend/Controllers/AccountsController.cs
@@ -5,10 +5,12 @@ using budget_tracker_backend.MediatR.Accounts.Commands.Delete;
 using budget_tracker_backend.MediatR.Accounts.Commands.Update;
 using budget_tracker_backend.MediatR.Accounts.Queries.GetAll;
 using budget_tracker_backend.MediatR.Accounts.Queries.GetById;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace budget_tracker_backend.Controllers;
 
+[Authorize]
 [Route("api/[controller]")]
 [ApiController]
 public class AccountsController : BaseApiController

--- a/budget-tracker-backend/Controllers/AuthController.cs
+++ b/budget-tracker-backend/Controllers/AuthController.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using budget_tracker_backend.Dto.Auth;
+using budget_tracker_backend.Models;
+using budget_tracker_backend.Services.Auth;
+
+namespace budget_tracker_backend.Controllers;
+
+[ApiController]
+[Route("auth")]
+public class AuthController : ControllerBase
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly ITokenService _tokenService;
+
+    public AuthController(UserManager<ApplicationUser> userManager, ITokenService tokenService)
+    {
+        _userManager = userManager;
+        _tokenService = tokenService;
+    }
+
+    [HttpPost("register")]
+    [AllowAnonymous]
+    public async Task<IActionResult> Register([FromBody] RegisterDto dto)
+    {
+        var user = new ApplicationUser { UserName = dto.Email, Email = dto.Email };
+        var result = await _userManager.CreateAsync(user, dto.Password);
+        if (!result.Succeeded)
+        {
+            return BadRequest(result.Errors);
+        }
+
+        var roles = await _userManager.GetRolesAsync(user);
+        var accessToken = _tokenService.CreateAccessToken(user, roles);
+        var refreshToken = _tokenService.CreateRefreshToken();
+        user.RefreshTokens.Add(refreshToken);
+        await _userManager.UpdateAsync(user);
+        return Ok(new AuthResponseDto { AccessToken = accessToken, RefreshToken = refreshToken.Token });
+    }
+
+    [HttpPost("login")]
+    [AllowAnonymous]
+    public async Task<IActionResult> Login([FromBody] LoginDto dto)
+    {
+        var user = await _userManager.FindByEmailAsync(dto.Email);
+        if (user == null || !await _userManager.CheckPasswordAsync(user, dto.Password))
+            return Unauthorized();
+
+        var roles = await _userManager.GetRolesAsync(user);
+        var accessToken = _tokenService.CreateAccessToken(user, roles);
+        var refreshToken = _tokenService.CreateRefreshToken();
+        user.RefreshTokens.Add(refreshToken);
+        await _userManager.UpdateAsync(user);
+        return Ok(new AuthResponseDto { AccessToken = accessToken, RefreshToken = refreshToken.Token });
+    }
+
+    [HttpPost("refresh")]
+    [AllowAnonymous]
+    public async Task<IActionResult> Refresh([FromBody] RefreshRequestDto request)
+    {
+        var principal = _tokenService.GetPrincipalFromExpiredToken(request.AccessToken);
+        if (principal?.Identity?.Name == null)
+            return BadRequest();
+        var user = await _userManager.FindByNameAsync(principal.Identity.Name);
+        if (user == null)
+            return BadRequest();
+
+        var refreshToken = user.RefreshTokens.FirstOrDefault(x => x.Token == request.RefreshToken && x.IsActive);
+        if (refreshToken == null)
+            return Unauthorized();
+
+        refreshToken.Revoked = DateTime.UtcNow;
+        var newRefreshToken = _tokenService.CreateRefreshToken();
+        user.RefreshTokens.Add(newRefreshToken);
+        var roles = await _userManager.GetRolesAsync(user);
+        var newAccessToken = _tokenService.CreateAccessToken(user, roles);
+        await _userManager.UpdateAsync(user);
+        return Ok(new AuthResponseDto { AccessToken = newAccessToken, RefreshToken = newRefreshToken.Token });
+    }
+
+    [Authorize]
+    [HttpPost("logout")]
+    public async Task<IActionResult> Logout([FromBody] RefreshRequestDto request)
+    {
+        var user = await _userManager.FindByNameAsync(User.Identity!.Name);
+        if (user == null)
+            return BadRequest();
+        var refreshToken = user.RefreshTokens.FirstOrDefault(x => x.Token == request.RefreshToken && x.IsActive);
+        if (refreshToken != null)
+        {
+            refreshToken.Revoked = DateTime.UtcNow;
+            await _userManager.UpdateAsync(user);
+        }
+        return Ok();
+    }
+}

--- a/budget-tracker-backend/Controllers/BudgetPlanItemsController.cs
+++ b/budget-tracker-backend/Controllers/BudgetPlanItemsController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using budget_tracker_backend.Dto.BudgetPlanItems;
 using budget_tracker_backend.MediatR.BudgetPlanItems.Commands.Create;
 using budget_tracker_backend.MediatR.BudgetPlanItems.Commands.Delete;
@@ -10,6 +11,7 @@ using budget_tracker_backend.MediatR.BudgetPlanItems.Queries.GetByPlanId;
 
 namespace budget_tracker_backend.Controllers;
 
+[Authorize]
 [Route("api/[controller]")]
 [ApiController]
 public class BudgetPlanItemsController : BaseApiController

--- a/budget-tracker-backend/Controllers/BudgetPlansController.cs
+++ b/budget-tracker-backend/Controllers/BudgetPlansController.cs
@@ -5,10 +5,12 @@ using budget_tracker_backend.MediatR.BudgetPlans.Commands.Delete;
 using budget_tracker_backend.MediatR.BudgetPlans.Commands.Update;
 using budget_tracker_backend.MediatR.BudgetPlans.Queries.GetAll;
 using budget_tracker_backend.MediatR.BudgetPlans.Queries.GetById;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace budget_tracker_backend.Controllers;
 
+[Authorize]
 [Route("api/[controller]")]
 [ApiController]
 public class BudgetPlansController : BaseApiController

--- a/budget-tracker-backend/Controllers/CategoriesController.cs
+++ b/budget-tracker-backend/Controllers/CategoriesController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using budget_tracker_backend.Dto.Categories;
 using budget_tracker_backend.MediatR.Categories.Commands.Create;
 using budget_tracker_backend.MediatR.Categories.Commands.Delete;
@@ -11,6 +12,7 @@ using budget_tracker_backend.Models.Enums;
 
 namespace budget_tracker_backend.Controllers;
 
+[Authorize(Roles="Admin")]
 [Route("api/[controller]")]
 [ApiController]
 public class CategoriesController : BaseApiController

--- a/budget-tracker-backend/Controllers/ComponentsController.cs
+++ b/budget-tracker-backend/Controllers/ComponentsController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using budget_tracker_backend.Controllers.Interfaces;
 using budget_tracker_backend.MediatR.Components.IncomeModal;
@@ -10,6 +11,7 @@ using budget_tracker_backend.Models.Enums;
 
 namespace budget_tracker_backend.Controllers;
 
+[Authorize]
 [Route("api/components")]
 [ApiController]
 public class ComponentsController : BaseApiController

--- a/budget-tracker-backend/Controllers/CurrenciesController.cs
+++ b/budget-tracker-backend/Controllers/CurrenciesController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using budget_tracker_backend.Dto.Currencies;
 using budget_tracker_backend.MediatR.Currencies.Commands.Create;
 using budget_tracker_backend.MediatR.Currencies.Commands.Delete;
@@ -9,6 +10,7 @@ using budget_tracker_backend.Controllers.Interfaces;
 
 namespace budget_tracker_backend.Controllers;
 
+[Authorize(Roles="Admin")]
 [Route("api/[controller]")]
 [ApiController]
 public class CurrenciesController : BaseApiController

--- a/budget-tracker-backend/Controllers/EventsController.cs
+++ b/budget-tracker-backend/Controllers/EventsController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using budget_tracker_backend.Dto.Events;
 using budget_tracker_backend.MediatR.Events.Commands.Create;
 using budget_tracker_backend.MediatR.Events.Commands.Delete;
@@ -10,6 +11,7 @@ using budget_tracker_backend.MediatR.Events.Queries.GetByIdWithTransactions;
 
 namespace budget_tracker_backend.Controllers;
 
+[Authorize]
 [Route("api/[controller]")]
 [ApiController]
 public class EventsController : BaseApiController

--- a/budget-tracker-backend/Controllers/PagesController.cs
+++ b/budget-tracker-backend/Controllers/PagesController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using budget_tracker_backend.MediatR.Pages.ExpensesByMonth;
 using budget_tracker_backend.MediatR.Pages.IncomesByMonth;
 using budget_tracker_backend.MediatR.Pages.TransfersByMonth;
@@ -9,6 +10,7 @@ using budget_tracker_backend.Controllers.Interfaces;
 
 namespace budget_tracker_backend.Controllers;
 
+[Authorize]
 [Route("api/pages")]
 [ApiController]
 public class PagesController : BaseApiController

--- a/budget-tracker-backend/Controllers/Transactions/ExpensesController.cs
+++ b/budget-tracker-backend/Controllers/Transactions/ExpensesController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using budget_tracker_backend.Dto.Transactions;
 using budget_tracker_backend.MediatR.Transactions.Commands.Create;
 using budget_tracker_backend.MediatR.Transactions.Queries.GetTransactions;
@@ -7,6 +8,7 @@ using budget_tracker_backend.Controllers.Interfaces;
 
 namespace budget_tracker_backend.Controllers.Transactions;
 
+[Authorize]
 [Route("api/[controller]")]
 [ApiController]
 public class ExpensesController : BaseApiController

--- a/budget-tracker-backend/Controllers/Transactions/IncomeController.cs
+++ b/budget-tracker-backend/Controllers/Transactions/IncomeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using budget_tracker_backend.Dto.Transactions;
 using budget_tracker_backend.MediatR.Transactions.Commands.Create;
 using budget_tracker_backend.MediatR.Transactions.Queries.GetTransactions;
@@ -7,6 +8,7 @@ using budget_tracker_backend.Controllers.Interfaces;
 
 namespace budget_tracker_backend.Controllers.Transactions;
 
+[Authorize]
 [Route("api/[controller]")]
 [ApiController]
 public class IncomeController : BaseApiController

--- a/budget-tracker-backend/Controllers/Transactions/TransactionsController.cs
+++ b/budget-tracker-backend/Controllers/Transactions/TransactionsController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using budget_tracker_backend.Dto.Transactions;
 using budget_tracker_backend.MediatR.Transactions.Commands.Delete;
 using budget_tracker_backend.MediatR.Transactions.Commands.Update;
@@ -14,6 +15,7 @@ using budget_tracker_backend.Services.Transactions;
 
 namespace budget_tracker_backend.Controllers.Transactions;
 
+[Authorize]
 [Route("api/[controller]")]
 [ApiController]
 public class TransactionsController : BaseApiController

--- a/budget-tracker-backend/Controllers/Transactions/TransfersController.cs
+++ b/budget-tracker-backend/Controllers/Transactions/TransfersController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using budget_tracker_backend.Dto.Transactions;
 using budget_tracker_backend.MediatR.Transactions.Commands.Create;
 using budget_tracker_backend.MediatR.Transactions.Queries.GetTransactions;
@@ -7,6 +8,7 @@ using budget_tracker_backend.Controllers.Interfaces;
 
 namespace budget_tracker_backend.Controllers.Transactions;
 
+[Authorize]
 [Route("api/[controller]")]
 [ApiController]
 public class TransfersController : BaseApiController

--- a/budget-tracker-backend/Data/ApplicationDbContext.cs
+++ b/budget-tracker-backend/Data/ApplicationDbContext.cs
@@ -1,11 +1,21 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using budget_tracker_backend.Models;
+using System.Security.Claims;
+using System.Linq;
+using System.Threading;
 
 namespace budget_tracker_backend.Data;
 
-public class ApplicationDbContext : DbContext, IApplicationDbContext
+public class ApplicationDbContext : IdentityDbContext<ApplicationUser>, IApplicationDbContext
 {
-    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) { }
+    private readonly IHttpContextAccessor _ctx;
+
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options, IHttpContextAccessor ctx) : base(options)
+    {
+        _ctx = ctx;
+    }
 
     public DbSet<Category> Categories { get; set; }
     public DbSet<Transaction> Transactions { get; set; }
@@ -14,68 +24,96 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
     public DbSet<BudgetPlanItem> BudgetPlanItems { get; set; }
     public DbSet<Currency> Currencies { get; set; }
     public DbSet<Event> Events { get; set; }
+    public DbSet<RefreshToken> RefreshTokens { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        modelBuilder.Entity<Account>()
-           .Property(a => a.Amount)
-           .HasColumnType("decimal(18,4)");
-
-        modelBuilder.Entity<BudgetPlanItem>()
-            .Property(bp => bp.Amount)
-            .HasColumnType("decimal(18,4)");
-
-        modelBuilder.Entity<BudgetPlanItem>()
-            .HasOne(i => i.BudgetPlan)
-            .WithMany(p => p.Items)
-            .HasForeignKey(i => i.BudgetPlanId)
-            .OnDelete(DeleteBehavior.Cascade);
-
-        modelBuilder.Entity<Transaction>()
-            .Property(t => t.Amount)
-            .HasColumnType("decimal(18,4)");
-
-        modelBuilder.Entity<Transaction>()
-            .Property(t => t.UnicCode)
-            .HasMaxLength(64);
-
-        modelBuilder.Entity<Transaction>()
-            .HasIndex(t => t.UnicCode);
-
-        // 1. Prohibit cascading deletion Event → Transaction
-        modelBuilder.Entity<Transaction>()
-            .HasOne(t => t.Event)
-            .WithMany(e => e.Transactions)
-            .HasForeignKey(t => t.EventId)
-            .OnDelete(DeleteBehavior.Restrict);
-
-        // 2. Allow deletion of Category (set NULL)
-        modelBuilder.Entity<Transaction>()
-            .HasOne(t => t.Category)
-            .WithMany()
-            .HasForeignKey(t => t.CategoryId)
-            .OnDelete(DeleteBehavior.SetNull);
-
-        // 3. Account deletion is prohibited if there are related Transactions
-        modelBuilder.Entity<Transaction>()
-            .HasOne(t => t.FromAccount)
-            .WithMany()
-            .HasForeignKey(t => t.AccountFrom)
-            .OnDelete(DeleteBehavior.Restrict);
-
-        modelBuilder.Entity<Transaction>()
-            .HasOne(t => t.ToAccount)
-            .WithMany()
-            .HasForeignKey(t => t.AccountTo)
-            .OnDelete(DeleteBehavior.Restrict);
-
-        // 4. Currency deletion is prohibited if there are related Transactions
-        modelBuilder.Entity<Transaction>()
-            .HasOne(t => t.Currency)
-            .WithMany()
-            .HasForeignKey(t => t.CurrencyId)
-            .OnDelete(DeleteBehavior.Restrict);
-
         base.OnModelCreating(modelBuilder);
+
+        var userId = _ctx.HttpContext?.User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        modelBuilder.Entity<Account>(b =>
+        {
+            b.Property(a => a.Amount).HasColumnType("decimal(18,4)");
+            b.HasQueryFilter(a => a.UserId == userId);
+            b.HasIndex(a => a.UserId);
+        });
+
+        modelBuilder.Entity<Category>(b =>
+        {
+            b.HasQueryFilter(c => c.UserId == userId);
+            b.HasIndex(c => c.UserId);
+        });
+
+        modelBuilder.Entity<BudgetPlan>(b =>
+        {
+            b.HasQueryFilter(p => p.UserId == userId);
+            b.HasIndex(p => p.UserId);
+        });
+
+        modelBuilder.Entity<Event>(b =>
+        {
+            b.HasQueryFilter(e => e.UserId == userId);
+            b.HasIndex(e => e.UserId);
+        });
+
+        modelBuilder.Entity<BudgetPlanItem>(b =>
+        {
+            b.Property(bp => bp.Amount).HasColumnType("decimal(18,4)");
+            b.HasOne(i => i.BudgetPlan)
+                .WithMany(p => p.Items)
+                .HasForeignKey(i => i.BudgetPlanId)
+                .OnDelete(DeleteBehavior.Cascade);
+            b.HasQueryFilter(i => i.BudgetPlan!.UserId == userId);
+        });
+
+        modelBuilder.Entity<Transaction>(b =>
+        {
+            b.Property(t => t.Amount).HasColumnType("decimal(18,4)");
+            b.Property(t => t.UnicCode).HasMaxLength(64);
+            b.HasIndex(t => t.UnicCode);
+            b.HasQueryFilter(t => t.UserId == userId);
+            b.HasIndex(t => new { t.UserId, t.Date });
+
+            b.HasOne(t => t.Event)
+                .WithMany(e => e.Transactions)
+                .HasForeignKey(t => t.EventId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            b.HasOne(t => t.Category)
+                .WithMany()
+                .HasForeignKey(t => t.CategoryId)
+                .OnDelete(DeleteBehavior.SetNull);
+
+            b.HasOne(t => t.FromAccount)
+                .WithMany()
+                .HasForeignKey(t => t.AccountFrom)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            b.HasOne(t => t.ToAccount)
+                .WithMany()
+                .HasForeignKey(t => t.AccountTo)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            b.HasOne(t => t.Currency)
+                .WithMany()
+                .HasForeignKey(t => t.CurrencyId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+    }
+
+    public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        var userId = _ctx.HttpContext?.User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        foreach (var entry in ChangeTracker.Entries<IUserOwnedEntity>().Where(e => e.State == EntityState.Added))
+        {
+            if (string.IsNullOrEmpty(entry.Entity.UserId) && userId != null)
+            {
+                entry.Entity.UserId = userId;
+            }
+        }
+
+        return base.SaveChangesAsync(cancellationToken);
     }
 }

--- a/budget-tracker-backend/Data/ApplicationDbContext.cs
+++ b/budget-tracker-backend/Data/ApplicationDbContext.cs
@@ -37,24 +37,40 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>, IApplica
             b.Property(a => a.Amount).HasColumnType("decimal(18,4)");
             b.HasQueryFilter(a => a.UserId == userId);
             b.HasIndex(a => a.UserId);
+            b.HasOne(a => a.User)
+                .WithMany()
+                .HasForeignKey(a => a.UserId)
+                .OnDelete(DeleteBehavior.Restrict);
         });
 
         modelBuilder.Entity<Category>(b =>
         {
             b.HasQueryFilter(c => c.UserId == userId);
             b.HasIndex(c => c.UserId);
+            b.HasOne(c => c.User)
+                .WithMany()
+                .HasForeignKey(c => c.UserId)
+                .OnDelete(DeleteBehavior.Restrict);
         });
 
         modelBuilder.Entity<BudgetPlan>(b =>
         {
             b.HasQueryFilter(p => p.UserId == userId);
             b.HasIndex(p => p.UserId);
+            b.HasOne(p => p.User)
+                .WithMany()
+                .HasForeignKey(p => p.UserId)
+                .OnDelete(DeleteBehavior.Restrict);
         });
 
         modelBuilder.Entity<Event>(b =>
         {
             b.HasQueryFilter(e => e.UserId == userId);
             b.HasIndex(e => e.UserId);
+            b.HasOne(e => e.User)
+                .WithMany()
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Restrict);
         });
 
         modelBuilder.Entity<BudgetPlanItem>(b =>
@@ -74,6 +90,11 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>, IApplica
             b.HasIndex(t => t.UnicCode);
             b.HasQueryFilter(t => t.UserId == userId);
             b.HasIndex(t => new { t.UserId, t.Date });
+
+            b.HasOne(t => t.User)
+                .WithMany()
+                .HasForeignKey(t => t.UserId)
+                .OnDelete(DeleteBehavior.Restrict);
 
             b.HasOne(t => t.Event)
                 .WithMany(e => e.Transactions)

--- a/budget-tracker-backend/Data/IApplicationDbContext.cs
+++ b/budget-tracker-backend/Data/IApplicationDbContext.cs
@@ -14,6 +14,7 @@ public interface IApplicationDbContext
     DbSet<BudgetPlanItem> BudgetPlanItems { get; }
     DbSet<Currency> Currencies { get; }
     DbSet<Event> Events { get; }
+    DbSet<RefreshToken> RefreshTokens { get; }
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken);
 }

--- a/budget-tracker-backend/Dto/Auth/AuthResponseDto.cs
+++ b/budget-tracker-backend/Dto/Auth/AuthResponseDto.cs
@@ -1,0 +1,7 @@
+namespace budget_tracker_backend.Dto.Auth;
+
+public class AuthResponseDto
+{
+    public string AccessToken { get; set; } = string.Empty;
+    public string RefreshToken { get; set; } = string.Empty;
+}

--- a/budget-tracker-backend/Dto/Auth/LoginDto.cs
+++ b/budget-tracker-backend/Dto/Auth/LoginDto.cs
@@ -1,0 +1,7 @@
+namespace budget_tracker_backend.Dto.Auth;
+
+public class LoginDto
+{
+    public string Email { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}

--- a/budget-tracker-backend/Dto/Auth/RefreshRequestDto.cs
+++ b/budget-tracker-backend/Dto/Auth/RefreshRequestDto.cs
@@ -1,0 +1,7 @@
+namespace budget_tracker_backend.Dto.Auth;
+
+public class RefreshRequestDto
+{
+    public string AccessToken { get; set; } = string.Empty;
+    public string RefreshToken { get; set; } = string.Empty;
+}

--- a/budget-tracker-backend/Dto/Auth/RegisterDto.cs
+++ b/budget-tracker-backend/Dto/Auth/RegisterDto.cs
@@ -1,0 +1,7 @@
+namespace budget_tracker_backend.Dto.Auth;
+
+public class RegisterDto
+{
+    public string Email { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}

--- a/budget-tracker-backend/Models/Account.cs
+++ b/budget-tracker-backend/Models/Account.cs
@@ -2,15 +2,18 @@
 
 namespace budget_tracker_backend.Models;
 
-public class Account
+public class Account : IUserOwnedEntity
 {
     public int Id { get; set; }
     public string Title { get; set; } = null!;
     public decimal Amount { get; set; }
     public int CurrencyId { get; set; }
     public string? Description { get; set; }
+    public string UserId { get; set; } = null!;
 
     // Navigation properties
     [JsonIgnore]
     public virtual Currency? Currency { get; set; }
+    [JsonIgnore]
+    public ApplicationUser? User { get; set; }
 }

--- a/budget-tracker-backend/Models/ApplicationUser.cs
+++ b/budget-tracker-backend/Models/ApplicationUser.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Identity;
+using System.Collections.Generic;
+
+namespace budget_tracker_backend.Models;
+
+public class ApplicationUser : IdentityUser
+{
+    public ICollection<RefreshToken> RefreshTokens { get; set; } = new List<RefreshToken>();
+}
+

--- a/budget-tracker-backend/Models/BudgetPlan.cs
+++ b/budget-tracker-backend/Models/BudgetPlan.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace budget_tracker_backend.Models;
 
-public class BudgetPlan
+public class BudgetPlan : IUserOwnedEntity
 {
     public int Id { get; set; }
     public string Title { get; set; } = null!;
@@ -11,8 +11,11 @@ public class BudgetPlan
     public DateTime EndDate { get; set; }
     public BudgetPlanType Type { get; set; }
     public string? Description { get; set; }
+    public string UserId { get; set; } = null!;
 
     // Navigation properties
     [JsonIgnore]
     public virtual ICollection<BudgetPlanItem>? Items { get; set; }
+    [JsonIgnore]
+    public ApplicationUser? User { get; set; }
 }

--- a/budget-tracker-backend/Models/Category.cs
+++ b/budget-tracker-backend/Models/Category.cs
@@ -1,11 +1,15 @@
-﻿using budget_tracker_backend.Models.Enums;
+using System.Text.Json.Serialization;
+using budget_tracker_backend.Models.Enums;
 
 namespace budget_tracker_backend.Models;
 
-public class Category
+public class Category : IUserOwnedEntity
 {
     public int Id { get; set; }
     public string Title { get; set; } = null!;
     public TransactionCategoryType Type { get; set; }
     public string? Description { get; set; }
+    public string UserId { get; set; } = null!;
+    [JsonIgnore]
+    public ApplicationUser? User { get; set; }
 }

--- a/budget-tracker-backend/Models/Event.cs
+++ b/budget-tracker-backend/Models/Event.cs
@@ -2,15 +2,18 @@
 
 namespace budget_tracker_backend.Models;
 
-public class Event
+public class Event : IUserOwnedEntity
 {
     public int Id { get; set; }
     public string Title { get; set; } = null!;
     public int BudgetPlanId { get; set; }
     public string? Description { get; set; }
     public List<Transaction> Transactions { get; set; } = [];
+    public string UserId { get; set; } = null!;
 
     // Navigation properties
     [JsonIgnore]
     public BudgetPlan? BudgetPlan { get; set; }
+    [JsonIgnore]
+    public ApplicationUser? User { get; set; }
 }

--- a/budget-tracker-backend/Models/IUserOwnedEntity.cs
+++ b/budget-tracker-backend/Models/IUserOwnedEntity.cs
@@ -1,0 +1,6 @@
+namespace budget_tracker_backend.Models;
+
+public interface IUserOwnedEntity
+{
+    string UserId { get; set; }
+}

--- a/budget-tracker-backend/Models/RefreshToken.cs
+++ b/budget-tracker-backend/Models/RefreshToken.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace budget_tracker_backend.Models;
+
+public class RefreshToken
+{
+    public int Id { get; set; }
+    public string Token { get; set; } = string.Empty;
+    public DateTime Expires { get; set; }
+    public DateTime Created { get; set; }
+    public string? CreatedByIp { get; set; }
+    public DateTime? Revoked { get; set; }
+    public string? RevokedByIp { get; set; }
+    public string? ReplacedByToken { get; set; }
+    public bool IsActive => Revoked == null && !IsExpired;
+    public bool IsExpired => DateTime.UtcNow >= Expires;
+}
+

--- a/budget-tracker-backend/Models/Transaction.cs
+++ b/budget-tracker-backend/Models/Transaction.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace budget_tracker_backend.Models;
 
-public class Transaction
+public class Transaction : IUserOwnedEntity
 {
     public int Id { get; set; }
     public string Title { get; set; } = null!;
@@ -15,9 +15,9 @@ public class Transaction
     public DateTime Date { get; set; }
     public string UnicCode { get; set; } = null!;
     public string? AuthCode { get; set; }
-
+    public string UserId { get; set; } = null!;
     public int? AccountFrom { get; set; }
-    public int? AccountTo { get; set; } 
+    public int? AccountTo { get; set; }
 
     public TransactionCategoryType Type { get; set; }
     public string? Description { get; set; }
@@ -35,4 +35,6 @@ public class Transaction
     public virtual Account? FromAccount { get; set; }
     [JsonIgnore]
     public virtual Account? ToAccount { get; set; }
+    [JsonIgnore]
+    public ApplicationUser? User { get; set; }
 }

--- a/budget-tracker-backend/Program.cs
+++ b/budget-tracker-backend/Program.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.OpenApi.Models;
 using System.Text;
 using MediatR;
 
@@ -62,7 +63,41 @@ builder.Services.AddAuthentication(options =>
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = "Budget Tracker API",
+        Version = "v1"
+    });
+
+    var securityScheme = new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        Scheme = "bearer",
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header,
+        Description = "Input your JWT to access this API"
+    };
+
+    options.AddSecurityDefinition("Bearer", securityScheme);
+
+    options.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
+});
 
 builder.Services.AddMediatR(currentAssemblies);
 builder.Services.AddAutoMapper(currentAssemblies);

--- a/budget-tracker-backend/Services/Auth/ITokenService.cs
+++ b/budget-tracker-backend/Services/Auth/ITokenService.cs
@@ -1,0 +1,11 @@
+using System.Security.Claims;
+using budget_tracker_backend.Models;
+
+namespace budget_tracker_backend.Services.Auth;
+
+public interface ITokenService
+{
+    string CreateAccessToken(ApplicationUser user, IList<string> roles);
+    RefreshToken CreateRefreshToken();
+    ClaimsPrincipal? GetPrincipalFromExpiredToken(string token);
+}

--- a/budget-tracker-backend/Services/Auth/TokenService.cs
+++ b/budget-tracker-backend/Services/Auth/TokenService.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+using budget_tracker_backend.Models;
+
+namespace budget_tracker_backend.Services.Auth;
+
+public class TokenService : ITokenService
+{
+    private readonly IConfiguration _config;
+    public TokenService(IConfiguration config)
+    {
+        _config = config;
+    }
+
+    public string CreateAccessToken(ApplicationUser user, IList<string> roles)
+    {
+        var authSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]!));
+
+        var authClaims = new List<Claim>
+        {
+            new Claim(ClaimTypes.NameIdentifier, user.Id),
+            new Claim(ClaimTypes.Name, user.UserName ?? user.Email ?? string.Empty),
+            new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+        };
+
+        foreach (var role in roles)
+        {
+            authClaims.Add(new Claim(ClaimTypes.Role, role));
+        }
+
+        var token = new JwtSecurityToken(
+            issuer: _config["Jwt:Issuer"],
+            audience: _config["Jwt:Audience"],
+            expires: DateTime.UtcNow.AddMinutes(15),
+            claims: authClaims,
+            signingCredentials: new SigningCredentials(authSigningKey, SecurityAlgorithms.HmacSha256)
+        );
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    public RefreshToken CreateRefreshToken()
+    {
+        var randomNumber = new byte[32];
+        using var rng = RandomNumberGenerator.Create();
+        rng.GetBytes(randomNumber);
+        return new RefreshToken
+        {
+            Token = Convert.ToBase64String(randomNumber),
+            Expires = DateTime.UtcNow.AddDays(7),
+            Created = DateTime.UtcNow
+        };
+    }
+
+    public ClaimsPrincipal? GetPrincipalFromExpiredToken(string token)
+    {
+        var tokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateAudience = true,
+            ValidateIssuer = true,
+            ValidIssuer = _config["Jwt:Issuer"],
+            ValidAudience = _config["Jwt:Audience"],
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]!)),
+            ValidateLifetime = false
+        };
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var principal = tokenHandler.ValidateToken(token, tokenValidationParameters, out var securityToken);
+        if (securityToken is not JwtSecurityToken jwt || jwt.Header.Alg.Equals(SecurityAlgorithms.HmacSha256, StringComparison.InvariantCultureIgnoreCase) == false)
+            throw new SecurityTokenException("Invalid token");
+        return principal;
+    }
+}

--- a/budget-tracker-backend/appsettings.Development.json
+++ b/budget-tracker-backend/appsettings.Development.json
@@ -4,5 +4,10 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Jwt": {
+    "Key": "super_secret_key_12345",
+    "Issuer": "budget_tracker_backend",
+    "Audience": "budget_tracker_backend"
   }
 }

--- a/budget-tracker-backend/appsettings.Development.json
+++ b/budget-tracker-backend/appsettings.Development.json
@@ -6,7 +6,7 @@
     }
   },
   "Jwt": {
-    "Key": "super_secret_key_12345",
+    "Key": "super_secret_development_key_which_is_at_least_32_chars",
     "Issuer": "budget_tracker_backend",
     "Audience": "budget_tracker_backend"
   }

--- a/budget-tracker-backend/appsettings.json
+++ b/budget-tracker-backend/appsettings.json
@@ -9,4 +9,10 @@
     }
   },
   "AllowedHosts": "*"
+  ,
+  "Jwt": {
+    "Key": "super_secret_key_12345",
+    "Issuer": "budget_tracker_backend",
+    "Audience": "budget_tracker_backend"
+  }
 }

--- a/budget-tracker-backend/appsettings.json
+++ b/budget-tracker-backend/appsettings.json
@@ -11,7 +11,7 @@
   "AllowedHosts": "*"
   ,
   "Jwt": {
-    "Key": "super_secret_key_12345",
+    "Key": "super_secret_development_key_which_is_at_least_32_chars",
     "Issuer": "budget_tracker_backend",
     "Audience": "budget_tracker_backend"
   }

--- a/budget-tracker-backend/budget-tracker-backend.csproj
+++ b/budget-tracker-backend/budget-tracker-backend.csproj
@@ -17,9 +17,9 @@
 	<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2" />
 	<PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
 	<PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-	<PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
-	<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
-	<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="9.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="9.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.1">
@@ -35,6 +35,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Track owning user across accounts, categories, budgets, events, and transactions
- Apply global query filters and indexes to isolate data per authenticated user
- Register HTTP context accessor and auto-populate UserId on entity creation

## Testing
- `dotnet ef migrations add AddUserOwnedEntities` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fc057b2f88330936846174f094c56