### PR TITLE
Add ChatGPT service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # budget-tracker-backend
+
+## ChatGPT service
+
+Service `ChatGptService` allows sending requests to OpenAI ChatGPT models.
+
+### Configuration
+
+Store OpenAI credentials using [user secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets):
+
+```bash
+cd budget-tracker-backend
+dotnet user-secrets init
+dotnet user-secrets set "OpenAI:ApiKey" "your_api_key"
+dotnet user-secrets set "OpenAI:DefaultModel" "gpt-3.5-turbo"
+```
+
+### Usage
+
+After configuring secrets, run the application and call the `POST /api/chatgpt/ask` endpoint via Swagger with a `ChatGptRequest` body to receive a response from ChatGPT.

--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ dotnet user-secrets set "OpenAI:DefaultModel" "gpt-3.5-turbo"
 ### Usage
 
 After configuring secrets, run the application and call the `POST /api/chatgpt/ask` endpoint via Swagger with a `ChatGptRequest` body to receive a response from ChatGPT.
+If the endpoint returns `429 Too Many Requests`, your API key may have exhausted its quota or you are sending requests too quickly.

--- a/budget-tracker-backend/Controllers/ChatGptController.cs
+++ b/budget-tracker-backend/Controllers/ChatGptController.cs
@@ -1,0 +1,26 @@
+using budget_tracker_backend.Dto.ChatGpt;
+using budget_tracker_backend.Services.ChatGpt;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace budget_tracker_backend.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ChatGptController : ControllerBase
+{
+    private readonly IChatGptService _chatGptService;
+
+    public ChatGptController(IChatGptService chatGptService)
+    {
+        _chatGptService = chatGptService;
+    }
+
+    [HttpPost("ask")]
+    [AllowAnonymous]
+    public async Task<ActionResult<string>> Ask([FromBody] ChatGptRequest request, CancellationToken cancellationToken)
+    {
+        var response = await _chatGptService.AskAsync(request, cancellationToken);
+        return Ok(response);
+    }
+}

--- a/budget-tracker-backend/Dto/ChatGpt/ChatGptRequest.cs
+++ b/budget-tracker-backend/Dto/ChatGpt/ChatGptRequest.cs
@@ -1,0 +1,27 @@
+namespace budget_tracker_backend.Dto.ChatGpt;
+
+public class ChatGptRequest
+{
+    /// <summary>Основная инструкция для чата.</summary>
+    public string Instruction { get; set; } = string.Empty;
+
+    /// <summary>Дополнительные данные, которые нужно передать модели.</summary>
+    public string? Data { get; set; }
+
+    /// <summary>Ключевые слова, которые должны быть использованы в ответе.</summary>
+    public IEnumerable<string>? Keywords { get; set; }
+
+    /// <summary>Желаемый формат ответа (например, "json", "markdown").</summary>
+    public string? ResponseFormat { get; set; }
+
+    /// <summary>
+    /// Модель OpenAI, например "gpt-3.5-turbo". Если не указана, используется значение по умолчанию из конфигурации.
+    /// </summary>
+    public string? Model { get; set; }
+
+    /// <summary>Температура генерации (0-2).</summary>
+    public double? Temperature { get; set; }
+
+    /// <summary>Максимальное количество токенов в ответе.</summary>
+    public int? MaxTokens { get; set; }
+}

--- a/budget-tracker-backend/Program.cs
+++ b/budget-tracker-backend/Program.cs
@@ -8,6 +8,7 @@ using budget_tracker_backend.Services.Currencies;
 using budget_tracker_backend.Services.Pages;
 using budget_tracker_backend.Services.Transactions;
 using budget_tracker_backend.Services.Auth;
+using budget_tracker_backend.Services.ChatGpt;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.EntityFrameworkCore;
@@ -19,6 +20,7 @@ using MediatR;
 using budget_tracker_backend.Models;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.Configuration.AddUserSecrets<Program>(optional: true);
 var currentAssemblies = AppDomain.CurrentDomain.GetAssemblies();
 
 
@@ -31,6 +33,7 @@ builder.Services.AddScoped<ICurrencyManager, CurrencyManager>();
 builder.Services.AddScoped<ITransactionManager, TransactionManager>();
 builder.Services.AddScoped<IPageManager, PageManager>();
 builder.Services.AddScoped<ITokenService, TokenService>();
+builder.Services.AddHttpClient<IChatGptService, ChatGptService>();
 // Ïîäêëþ÷àåì EF Core è MS SQL
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));

--- a/budget-tracker-backend/Services/ChatGpt/ChatGptService.cs
+++ b/budget-tracker-backend/Services/ChatGpt/ChatGptService.cs
@@ -1,0 +1,75 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using budget_tracker_backend.Dto.ChatGpt;
+
+namespace budget_tracker_backend.Services.ChatGpt;
+
+public class ChatGptService : IChatGptService
+{
+    private readonly HttpClient _httpClient;
+    private readonly IConfiguration _configuration;
+
+    public ChatGptService(HttpClient httpClient, IConfiguration configuration)
+    {
+        _httpClient = httpClient;
+        _configuration = configuration;
+    }
+
+    public async Task<string> AskAsync(ChatGptRequest request, CancellationToken cancellationToken = default)
+    {
+        var apiKey = _configuration["OpenAI:ApiKey"];
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            throw new InvalidOperationException("OpenAI:ApiKey не настроен. Укажите ключ в user secrets.");
+        }
+
+        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        var baseUrl = _configuration["OpenAI:BaseUrl"] ?? "https://api.openai.com/v1";
+        var endpoint = baseUrl.TrimEnd('/') + "/chat/completions";
+        var model = request.Model ?? _configuration["OpenAI:DefaultModel"] ?? "gpt-3.5-turbo";
+        var prompt = BuildPrompt(request);
+
+        var payload = new
+        {
+            model,
+            messages = new[]
+            {
+                new { role = "user", content = prompt }
+            },
+            temperature = request.Temperature,
+            max_tokens = request.MaxTokens
+        };
+
+        var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+        var response = await _httpClient.PostAsync(endpoint, content, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+        using var document = JsonDocument.Parse(body);
+        var message = document.RootElement
+            .GetProperty("choices")[0]
+            .GetProperty("message")
+            .GetProperty("content")
+            .GetString();
+        return message ?? string.Empty;
+    }
+
+    private static string BuildPrompt(ChatGptRequest request)
+    {
+        var builder = new StringBuilder(request.Instruction.Trim());
+        if (!string.IsNullOrWhiteSpace(request.Data))
+        {
+            builder.AppendLine().Append("Данные: ").AppendLine(request.Data);
+        }
+        if (request.Keywords != null && request.Keywords.Any())
+        {
+            builder.AppendLine().Append("Ключевые слова: ").Append(string.Join(", ", request.Keywords));
+        }
+        if (!string.IsNullOrWhiteSpace(request.ResponseFormat))
+        {
+            builder.AppendLine().Append("Ответь в формате: ").Append(request.ResponseFormat);
+        }
+        return builder.ToString();
+    }
+}

--- a/budget-tracker-backend/Services/ChatGpt/IChatGptService.cs
+++ b/budget-tracker-backend/Services/ChatGpt/IChatGptService.cs
@@ -1,0 +1,11 @@
+using budget_tracker_backend.Dto.ChatGpt;
+
+namespace budget_tracker_backend.Services.ChatGpt;
+
+public interface IChatGptService
+{
+    /// <summary>
+    /// Отправляет запрос к модели ChatGPT и возвращает текст ответа.
+    /// </summary>
+    Task<string> AskAsync(ChatGptRequest request, CancellationToken cancellationToken = default);
+}


### PR DESCRIPTION
## Summary
- load OpenAI settings from user secrets instead of appsettings file
- expose `/api/chatgpt/ask` endpoint for testing ChatGPT service
- update README with user secrets setup instructions

## Testing
- `dotnet build` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c0965ccc1c833090551a553da51ddf