### PR TITLE
Sanitize AI PDF response before deserializing

### DIFF
--- a/budget-tracker-backend/Controllers/PdfController.cs
+++ b/budget-tracker-backend/Controllers/PdfController.cs
@@ -1,0 +1,376 @@
+using System;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using budget_tracker_backend.Dto.Pdf;
+using budget_tracker_backend.Dto.Transactions;
+using budget_tracker_backend.Models;
+using budget_tracker_backend.Models.Enums;
+using budget_tracker_backend.Services.Categories;
+using budget_tracker_backend.Services.ChatGpt;
+using budget_tracker_backend.Services.Transactions;
+using iText.Kernel.Pdf;
+using iText.Kernel.Pdf.Canvas.Parser;
+using iText.Kernel.Pdf.Canvas.Parser.Listener;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+
+namespace budget_tracker_backend.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class PdfController : ControllerBase
+{
+    private static readonly string[] SupportedDateFormats =
+    {
+        "yyyy-MM-dd",
+        "dd.MM.yyyy",
+        "dd.MM.yy",
+        "dd/MM/yyyy",
+        "dd/MM/yy",
+        "dd-MM-yyyy",
+        "dd-MM-yy"
+    };
+
+    private static readonly CultureInfo[] DateCultures =
+    {
+        CultureInfo.InvariantCulture,
+        new("uk-UA"),
+        new("ru-RU"),
+        CultureInfo.GetCultureInfo("en-GB")
+    };
+
+    private readonly IChatGptService _chatGptService;
+    private readonly ITransactionManager _transactionManager;
+    private readonly ICategoryManager _categoryManager;
+
+    public PdfController(
+        IChatGptService chatGptService,
+        ITransactionManager transactionManager,
+        ICategoryManager categoryManager)
+    {
+        _chatGptService = chatGptService;
+        _transactionManager = transactionManager;
+        _categoryManager = categoryManager;
+    }
+
+    [HttpPost("parse")]
+    [Authorize]
+    [Consumes("multipart/form-data")]
+    public async Task<ActionResult<IEnumerable<PreparedTransactionDto>>> ParsePdf(
+        [FromForm] ParsePdfRequest request,
+        CancellationToken ct)
+    {
+        var file = request.File;
+        if (file == null || file.Length == 0)
+            return BadRequest("File is empty");
+
+        using var stream = new MemoryStream();
+        await file.CopyToAsync(stream, ct);
+        stream.Position = 0;
+
+        var text = new StringBuilder();
+        using var reader = new PdfReader(stream);
+        using var document = new PdfDocument(reader);
+
+        for (var i = 1; i <= document.GetNumberOfPages(); i++)
+        {
+            var page = document.GetPage(i);
+            var strategy = new SimpleTextExtractionStrategy();
+            text.AppendLine(PdfTextExtractor.GetTextFromPage(page, strategy));
+        }
+
+        var statementText = text.ToString();
+
+        var expenses = await _categoryManager.GetByTypeAsync(TransactionCategoryType.Expense, ct);
+        var incomes = await _categoryManager.GetByTypeAsync(TransactionCategoryType.Income, ct);
+        var transfers = await _categoryManager.GetByTypeAsync(TransactionCategoryType.Transaction, ct);
+
+        var instruction = """
+Ты финансовый ассистент, который превращает текст банковской выписки в структурированные данные пользователя.
+1. Проанализируй выписку и найди все операции.
+2. Для каждой операции сформируй один JSON-объект.
+
+Требования к полям объекта:
+- "Title" — краткое название из 1–4 слов, отражающее суть операции.
+- "Amount" — число с точностью до копеек. Расходы и комиссии делай отрицательными, доходы положительными, переводы указывай со знаком, который соответствует направлению операции.
+- "Currency" — буквенный код валюты (например, UAH, USD).
+- "Date" — дата операции в формате YYYY-MM-DD.
+- "Type" — одно из значений: Income (зачисления), Expense (расходы и комиссии), Transaction (переводы между счетами).
+- "Category" — выбери подходящую категорию из списка категорий соответствующего типа. Если подходящей нет, верни пустую строку.
+- "Description" — полное описание операции из выписки.
+- "AuthCode" — код авторизации из выписки или null, если его нет.
+- "AccountFrom" и "AccountTo" — указывай только если по тексту однозначно понятно, какие счета задействованы. Иначе верни null.
+
+Верни строго JSON-массив без дополнительных комментариев. Если операций нет — верни []
+""";
+
+        var dataBuilder = new StringBuilder();
+        AppendCategoryList(dataBuilder, "Категории расходов", expenses);
+        AppendCategoryList(dataBuilder, "Категории доходов", incomes);
+        AppendCategoryList(dataBuilder, "Категории переводов", transfers);
+        dataBuilder.AppendLine("Текст выписки:").AppendLine(statementText);
+
+        var chatRequest = new ChatGptRequest
+        {
+            Instruction = instruction,
+            Data = dataBuilder.ToString(),
+            ResponseFormat = "json",
+            Temperature = 0,
+            MaxTokens = CalculateMaxTokens(statementText.Length)
+        };
+
+        var aiResponse = await _chatGptService.AskAsync(chatRequest, ct);
+
+        var sanitizedResponse = SanitizeJsonResponse(ExtractJsonPayload(aiResponse));
+        if (string.IsNullOrWhiteSpace(sanitizedResponse))
+            sanitizedResponse = "[]";
+
+        List<AiParsedTransactionDto>? imported;
+        try
+        {
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            options.Converters.Add(new JsonStringEnumConverter());
+            imported = JsonSerializer.Deserialize<List<AiParsedTransactionDto>>(sanitizedResponse, options);
+        }
+        catch (JsonException)
+        {
+            return BadRequest("Failed to parse AI response");
+        }
+
+        if (imported == null)
+            return Ok(Array.Empty<PreparedTransactionDto>());
+
+        var normalized = new List<ImportTransactionDto>();
+        foreach (var item in imported)
+        {
+            if (!TryNormalize(item, out var dto, out var error))
+                return BadRequest(error);
+
+            normalized.Add(dto);
+        }
+
+        if (normalized.Count == 0)
+            return Ok(Array.Empty<PreparedTransactionDto>());
+
+        var prepared = await _transactionManager.PrepareAsync(normalized, ct);
+        return Ok(prepared);
+    }
+
+    private static void AppendCategoryList(StringBuilder builder, string title, IEnumerable<Category> categories)
+    {
+        var list = categories
+            .Select(c => c.Title)
+            .Where(c => !string.IsNullOrWhiteSpace(c))
+            .ToArray();
+
+        builder
+            .Append(title)
+            .Append(": ")
+            .AppendLine(list.Length == 0 ? "(нет категорий)" : string.Join(", ", list));
+    }
+
+    private static int CalculateMaxTokens(int statementLength)
+    {
+        if (statementLength <= 0)
+            return 512;
+
+        var estimated = statementLength / 3;
+        return Math.Clamp(estimated, 512, 6000);
+    }
+
+    private static bool TryNormalize(
+        AiParsedTransactionDto source,
+        out ImportTransactionDto result,
+        out string? error)
+    {
+        result = null!;
+        error = null;
+
+        if (source == null)
+        {
+            error = "AI response contains null transaction entry.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(source.Title))
+        {
+            error = "Transaction title is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(source.Currency))
+        {
+            error = $"Currency is required for transaction '{source.Title}'.";
+            return false;
+        }
+
+        if (!TryParseDate(source.Date, out var date))
+        {
+            error = $"Cannot parse date '{source.Date}' for transaction '{source.Title}'. Use YYYY-MM-DD format.";
+            return false;
+        }
+
+        result = new ImportTransactionDto
+        {
+            Title = source.Title.Trim(),
+            Amount = source.Amount,
+            Currency = source.Currency.Trim(),
+            AccountFrom = source.AccountFrom,
+            AccountTo = source.AccountTo,
+            Date = date,
+            Type = source.Type,
+            Category = string.IsNullOrWhiteSpace(source.Category) ? null : source.Category.Trim(),
+            Description = source.Description,
+            AuthCode = source.AuthCode
+        };
+
+        return true;
+    }
+
+    private static bool TryParseDate(string? value, out DateTime date)
+    {
+        date = default;
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        foreach (var culture in DateCultures)
+        {
+            if (DateTime.TryParseExact(value, SupportedDateFormats, culture, DateTimeStyles.AssumeLocal, out date))
+                return true;
+        }
+
+        foreach (var culture in DateCultures)
+        {
+            if (DateTime.TryParse(value, culture, DateTimeStyles.AssumeLocal, out date))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string ExtractJsonPayload(string response)
+    {
+        if (string.IsNullOrWhiteSpace(response))
+            return string.Empty;
+
+        var trimmed = response.Trim();
+
+        if (trimmed.StartsWith("```", StringComparison.Ordinal))
+        {
+            trimmed = RemoveCodeFence(trimmed);
+        }
+
+        var start = trimmed.IndexOf('[', StringComparison.Ordinal);
+        if (start >= 0)
+        {
+            var end = trimmed.LastIndexOf(']', StringComparison.Ordinal);
+            if (end >= start)
+                return trimmed.Substring(start, end - start + 1);
+        }
+
+        return trimmed;
+    }
+
+    private static string RemoveCodeFence(string fenced)
+    {
+        var content = fenced;
+
+        var firstLineEnd = content.IndexOfAny(new[] { '\n', '\r' });
+        if (firstLineEnd >= 0)
+        {
+            var header = content[..firstLineEnd].Trim();
+            if (header.StartsWith("```", StringComparison.Ordinal))
+            {
+                content = content[(firstLineEnd + 1)..];
+                content = content.TrimStart('\r', '\n');
+
+                if (content.StartsWith("json", StringComparison.OrdinalIgnoreCase))
+                {
+                    var secondLineEnd = content.IndexOfAny(new[] { '\n', '\r' });
+                    if (secondLineEnd >= 0)
+                    {
+                        content = content[(secondLineEnd + 1)..];
+                        content = content.TrimStart('\r', '\n');
+                    }
+                    else
+                    {
+                        content = string.Empty;
+                    }
+                }
+            }
+        }
+
+        var closing = content.LastIndexOf("```", StringComparison.Ordinal);
+        if (closing >= 0)
+            content = content[..closing];
+
+        return content.Trim();
+    }
+
+    private static string SanitizeJsonResponse(string response)
+    {
+        if (string.IsNullOrEmpty(response))
+            return response;
+
+        var builder = new StringBuilder(response.Length + 16);
+        var inString = false;
+        var escapeNext = false;
+
+        for (var i = 0; i < response.Length; i++)
+        {
+            var ch = response[i];
+
+            if (escapeNext)
+            {
+                builder.Append(ch);
+                escapeNext = false;
+                continue;
+            }
+
+            if (ch == '\\')
+            {
+                if (!inString)
+                {
+                    builder.Append(ch);
+                    continue;
+                }
+
+                var next = i + 1 < response.Length ? response[i + 1] : (char?)null;
+                if (next == null)
+                {
+                    builder.Append("\\\\");
+                    continue;
+                }
+
+                if (IsValidJsonEscape(next.Value))
+                {
+                    builder.Append('\\');
+                    escapeNext = true;
+                }
+                else
+                {
+                    builder.Append("\\\\");
+                }
+
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                inString = !inString;
+                builder.Append(ch);
+                continue;
+            }
+
+            builder.Append(ch);
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool IsValidJsonEscape(char c)
+        => c is '\\' or '"' or '/' or 'b' or 'f' or 'n' or 'r' or 't' or 'u';
+}

--- a/budget-tracker-backend/Dto/Pdf/AiParsedTransactionDto.cs
+++ b/budget-tracker-backend/Dto/Pdf/AiParsedTransactionDto.cs
@@ -1,0 +1,17 @@
+using budget_tracker_backend.Models.Enums;
+
+namespace budget_tracker_backend.Dto.Pdf;
+
+public class AiParsedTransactionDto
+{
+    public string Title { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public string Currency { get; set; } = string.Empty;
+    public int? AccountFrom { get; set; }
+    public int? AccountTo { get; set; }
+    public string Date { get; set; } = string.Empty;
+    public TransactionCategoryType Type { get; set; }
+    public string? Category { get; set; }
+    public string? Description { get; set; }
+    public string? AuthCode { get; set; }
+}

--- a/budget-tracker-backend/Dto/Pdf/ParsePdfRequest.cs
+++ b/budget-tracker-backend/Dto/Pdf/ParsePdfRequest.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Http;
+using System.ComponentModel.DataAnnotations;
+
+namespace budget_tracker_backend.Dto.Pdf;
+
+public class ParsePdfRequest
+{
+    [Required]
+    public IFormFile File { get; set; } = default!;
+}

--- a/budget-tracker-backend/Dto/Transactions/ImportTransactionDto.cs
+++ b/budget-tracker-backend/Dto/Transactions/ImportTransactionDto.cs
@@ -15,6 +15,8 @@ public class ImportTransactionDto
     public int? AccountTo { get; set; }
     public DateTime Date { get; set; }
     public TransactionCategoryType Type { get; set; }
+    /// <summary>Category title to match existing user categories.</summary>
+    public string? Category { get; set; }
     public string? Description { get; set; }
     public string? AuthCode { get; set; }
 }

--- a/budget-tracker-backend/Program.cs
+++ b/budget-tracker-backend/Program.cs
@@ -114,20 +114,6 @@ builder.Services.AddCors(options =>
 });
 
 var app = builder.Build();
-
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
-
-app.UseHttpsRedirection();
-app.UseAuthentication();
-app.UseAuthorization();
-app.MapControllers();
-
-app.UseCors("AllowReact"); // Âêëþ÷àåì CORS
-
 app.UseExceptionHandler(appBuilder =>
 {
     appBuilder.Run(async context =>
@@ -142,6 +128,19 @@ app.UseExceptionHandler(appBuilder =>
         await context.Response.WriteAsync("An unexpected error occurred.");
     });
 });
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+app.UseAuthentication();
+app.UseAuthorization();
+app.MapControllers();
+
+app.UseCors("AllowReact"); // Âêëþ÷àåì CORS
 
 app.UseStatusCodePages(async context =>
 {

--- a/budget-tracker-backend/Services/Transactions/TransactionManager.cs
+++ b/budget-tracker-backend/Services/Transactions/TransactionManager.cs
@@ -212,6 +212,14 @@ public class TransactionManager : ITransactionManager
                 .Select(c => (int?)c.Id)
                 .FirstOrDefaultAsync(ct);
 
+            if (!string.IsNullOrWhiteSpace(item.Category))
+            {
+                prepared.CategoryId = await _context.Categories
+                    .Where(c => c.Title == item.Category)
+                    .Select(c => (int?)c.Id)
+                    .FirstOrDefaultAsync(ct);
+            }
+
             var last = await _context.Transactions
                 .Where(t => t.Title == item.Title)
                 .OrderByDescending(t => t.Date)
@@ -220,7 +228,8 @@ public class TransactionManager : ITransactionManager
             if (last != null)
             {
                 prepared.BudgetPlanId = last.BudgetPlanId;
-                prepared.CategoryId = last.CategoryId;
+                if (!prepared.CategoryId.HasValue)
+                    prepared.CategoryId = last.CategoryId;
             }
 
             var unic = GenerateUnicCode(prepared.Amount ?? 0m, prepared.Date ?? item.Date, prepared.AuthCode);

--- a/budget-tracker-backend/budget-tracker-backend.csproj
+++ b/budget-tracker-backend/budget-tracker-backend.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
+    <PackageReference Include="itext7" Version="7.2.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- sanitize ChatGPT PDF parsing responses by stripping code fences, fixing bare backslashes, and defaulting to an empty array before deserializing
- reuse the cleaned payload when normalizing AI transactions to avoid JSON parsing errors triggered by invalid escape sequences

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c69599a27c8330b76e792500ae2d15