### PR TITLE
Add SonarQube coverage workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,50 @@ dotnet user-secrets set "OpenAI:DefaultModel" "gpt-3.5-turbo"
 
 After configuring secrets, run the application and call the `POST /api/chatgpt/ask` endpoint via Swagger with a `ChatGptRequest` body to receive a response from ChatGPT.
 If the endpoint returns `429 Too Many Requests`, your API key may have exhausted its quota or you are sending requests too quickly.
+
+## SonarQube test coverage
+
+The test project already uses `coverlet.collector`, and this repository now includes:
+
+- `coverage.runsettings` to force the `XPlat Code Coverage` collector to emit OpenCover output.
+- `scripts/run-sonar-coverage.sh` to run the test suite and place coverage files under `TestResults/`.
+
+### Generate coverage locally
+
+```bash
+./scripts/run-sonar-coverage.sh
+```
+
+After the command finishes, SonarQube-compatible coverage files will be created under:
+
+```bash
+TestResults/**/coverage.opencover.xml
+```
+
+### SonarScanner for .NET example
+
+If you run SonarQube analysis manually or in CI, pass the OpenCover report path to the scanner:
+
+```bash
+dotnet sonarscanner begin \
+  /k:"your_project_key" \
+  /d:sonar.host.url="https://your-sonarqube.example.com" \
+  /d:sonar.token="<your-token>" \
+  /d:sonar.cs.opencover.reportsPaths="TestResults/**/coverage.opencover.xml"
+
+dotnet build budget-tracker-backend.sln
+./scripts/run-sonar-coverage.sh
+dotnet sonarscanner end /d:sonar.token="<your-token>"
+```
+
+### Что нужно сделать вручную
+
+- Установить `dotnet-sonarscanner`, если он ещё не установлен:
+
+  ```bash
+  dotnet tool install --global dotnet-sonarscanner
+  ```
+
+- Подставить свои значения для `your_project_key`, `sonar.host.url` и `sonar.token`.
+- Добавить эти команды в ваш CI/CD пайплайн, если SonarQube должен считать coverage автоматически на каждом пуше или pull request.
+

--- a/coverage.runsettings
+++ b/coverage.runsettings
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>opencover</Format>
+          <ExcludeByFile>**/Migrations/*.cs</ExcludeByFile>
+          <ExcludeByFile>**/Program.cs</ExcludeByFile>
+          <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/scripts/run-sonar-coverage.sh
+++ b/scripts/run-sonar-coverage.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RESULTS_DIR="${ROOT_DIR}/TestResults"
+
+rm -rf "${RESULTS_DIR}"
+
+cd "${ROOT_DIR}"
+dotnet test budget-tracker-backend.sln \
+  --settings coverage.runsettings \
+  --collect:"XPlat Code Coverage" \
+  --results-directory "${RESULTS_DIR}"
+
+find "${RESULTS_DIR}" -type f -name 'coverage.opencover.xml' -print


### PR DESCRIPTION
### Motivation

- Provide SonarQube-compatible test coverage for this .NET solution by emitting OpenCover-format reports from the existing `coverlet.collector` test configuration. 

### Description

- Add `coverage.runsettings` to force the `XPlat Code Coverage` collector to output OpenCover (`coverage.opencover.xml`) and exclude `**/Migrations/*.cs`, `**/Program.cs`, and generated attributes.  
- Add `scripts/run-sonar-coverage.sh` to run `dotnet test` with the runsettings, clear `TestResults/`, and print generated `TestResults/**/coverage.opencover.xml` paths.  
- Update `README.md` with local usage instructions, a `dotnet sonarscanner` example showing how to pass `sonar.cs.opencover.reportsPaths`, and manual steps (install `dotnet-sonarscanner` and provide `your_project_key`, `sonar.host.url`, `sonar.token`).

### Testing

- Attempted to run `./scripts/run-sonar-coverage.sh`, but it failed in the execution environment because `dotnet` is not installed (so coverage generation could not be validated here).  
- Verified the repository was updated and committed (`git status` clean after commit and commit short id `9dbdb00`).  
- Confirmed the test project already references `coverlet.collector` and will produce OpenCover output when run in an environment with the .NET SDK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1193df674833087b24a3141c6b27f)